### PR TITLE
Add jarp-mcp and fastMCP4J (Java MCP servers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [tgeselle/bugsnag-mcp](https://github.com/tgeselle/bugsnag-mcp)        | 用于与 Bugsnag 交互的 MCP 服务器。                                         | 社区实现, TypeScript 开发 📇, 云服务 ☁️, Bugsnag 集成。                              |
 | [jordandalton/restcsv-mcp-server](https://github.com/JordanDalton/RestCsvMcpServer) | 用于 CSV 文件的 MCP 服务器。                                               | 社区实现, TypeScript 开发 📇, 云服务 ☁️, CSV 处理。                                 |
 | [jjsantos01/jupyter-notebook-mcp](https://github.com/jjsantos01/jupyter-notebook-mcp) | 将 Jupyter Notebook 连接到 Claude AI，允许 Claude 直接交互和控制 Jupyter。 | 社区实现, Python 开发 🐍, 本地运行 🏠, Jupyter 集成。                               |
-| [Lstmxx/yapi-mcp-server](https://github.com/Lstmxx/yapi-mcp-server) | 一个用 LLM 将 Yapi 的 API 定义自动化生成为 TypeScript 代码的MCP服务                               |社区实现, TypeScript 开发 📇,本地运行 🏠
+| [Lstmxx/yapi-mcp-server](https://github.com/Lstmxx/yapi-mcp-server) | 一个用 LLM 将 Yapi 的 API 定义自动化生成为 TypeScript 代码的MCP服务                               |社区实现, TypeScript 开发 📇,本地运行 🏠 |
+| [tersePrompts/jarp-mcp](https://github.com/tersePrompts/jarp-mcp) | Java Archive Reader Protocol - 为 AI 代理提供对 Maven 依赖中反编译 Java 代码的即时访问，如同为 AI 装上"X 光透视眼"。 | 社区实现 🌟, Node.js/Java 开发 ☕🟢, 本地运行 🏠, Java 类分析与反编译, CFR 内置, 智能缓存 |
+| [tersePrompts/fastMCP4J](https://github.com/tersePrompts/fastMCP4J) | Java 语言构建 MCP 服务器的轻量级注解驱动框架，JSON Schema 2020-12 兼容，安全、快速、零配置。 | 社区实现 🌟, Java 开发 ☕, 本地运行 🏠, 注解驱动, 12 个依赖, 支持异步、内存、任务、文件操作 |
 
 
 ---


### PR DESCRIPTION
## Summary

This PR adds two Java-related MCP servers to the list:

### 1. [jarp-mcp](https://github.com/tersePrompts/jarp-mcp)
- **Description**: Java Archive Reader Protocol - MCP server that gives AI agents instant access to decompiled Java code from Maven dependencies
- **Key Features**:
  - Blazing fast Java class analysis (1-2 seconds with caching)
  - Zero configuration - automatically scans `pom.xml` and `~/.m2/repository`
  - Built-in CFR 0.152 decompiler - no external dependencies
  - Smart caching for instant subsequent lookups
- **Installation**: `npx jarp-mcp`
- **License**: Apache-2.0

### 2. [fastMCP4J](https://github.com/tersePrompts/fastMCP4J)
- **Description**: Java framework for building MCP servers with annotations
- **Key Features**:
  - Annotation-driven development - just annotate and run
  - Lightweight - only 12 dependencies
  - JSON Schema 2020-12 compliant
  - Built-in tools: memory, todo, planner, file operations, bash execution, telemetry
- **Installation**: Maven dependency `io.github.terseprompts.fastmcp:fastmcp-java:0.3.1-beta`
- **License**: MIT

Both projects are actively maintained and fill an important gap in the MCP ecosystem for Java developers.

## Test plan

- [x] Verified entries follow the existing format in the README
- [x] Confirmed repository links are correct
- [x] Ensured proper categorization under "开发与代码执行" (Development & Code Execution)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)