### PR TITLE
添加 lc2mcp - LangChain 转 FastMCP 工具库

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,6 +921,10 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 
 - [Model Context Protocol(MCP) 编程极速入门](http://github.com/liaokongVFX/MCP-Chinese-Getting-Started-Guide)
 
+#### 3. MCP 开发工具库
+
+- [lc2mcp](https://github.com/xiaotonng/lc2mcp) 🐍 - 一行代码将 LangChain 工具转换为 FastMCP 工具，支持上下文注入和 1000+ langchain-community 工具
+
 ---
 
 ## Star History


### PR DESCRIPTION
## 描述

在 MCP Server 开发部分添加 [lc2mcp](https://github.com/xiaotonng/lc2mcp) 工具库。

**lc2mcp** 是一个 Python 库，可以一行代码将 LangChain 工具转换为 FastMCP 工具。

## 主要特性

- 🔄 任意 LangChain 工具即时转换为 FastMCP 工具
- 📦 支持 1000+ langchain-community 工具（DuckDuckGo、Wikipedia、SQL 等）
- 🔐 支持上下文注入（ToolRuntime、MCP Context）
- 📊 完整支持 MCP 进度通知和日志

## 快速示例

```python
from langchain_core.tools import tool
from fastmcp import FastMCP
from lc2mcp import register_tools

@tool
def get_weather(city: str) -> str:
    """获取城市天气。"""
    return f"晴天，25°C，{city}"

mcp = FastMCP("weather-server")
register_tools(mcp, [get_weather])  # 就这么简单！
```

## 安装

```bash
pip install lc2mcp
```

Made with [Cursor](https://cursor.com)