### PR TITLE
Add boj-mcp: 日本银行统计数据的 MCP 服务器

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,8 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [SaintDoresh/YFinance-Trader-MCP-ClaudeDesktop](https://github.com/SaintDoresh/YFinance-Trader-MCP-ClaudeDesktop.git) | 使用 Yahoo Finance API 提供股市数据和分析的 MCP 工具。                                          | 社区实现, Python 开发 🐍, 云服务 ☁️, Yahoo Finance 数据分析。                                       |
 | [Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server) | 使用 Solana Agent Kit 与 Solana 区块链交互，支持 40+ 协议操作。                                        | 社区实现, TypeScript 开发, Solana 链交互。                                                         |
 | [AlphaVantage](https://github.com/calvernaz/alphavantage)                          | AlphaVantage 股票市场数据 API 服务器。                                                              | 社区实现, Python 开发, AlphaVantage 金融数据。                                                      |
+| [boj-mcp](https://github.com/ajtgjmdjp/boj-mcp) | 日本银行统计数据的 MCP 服务器。访问 CGPI（企业商品价格指数）、短观调查、资金循环、国际收支等 16 个数据集。无需 API 密钥。 | Python 实现 🐍, 无需认证, 日银统计数据 |
+
 
 ---
 


### PR DESCRIPTION
## boj-mcp 简介

[boj-mcp](https://github.com/ajtgjmdjp/boj-mcp) 是首个 Python 实现的日本银行统计数据 MCP 服务器（此前仅有 R 语言的 BOJ 包）。

**主要功能：**
- 访问 16 个日本银行统计数据集（CGPI 企业商品价格指数、短观调查、资金循环、国际收支、BIS 统计等）
- 自动处理 Shift_JIS 编码的 CSV 文件
- 支持 Polars DataFrame 导出
- **无需 API 密钥** - 所有数据完全公开
- 已发布至 [PyPI](https://pypi.org/project/boj-mcp/)

**相关项目：**
- [edinet-mcp](https://github.com/ajtgjmdjp/edinet-mcp) - 日本企业财务数据（EDINET）
- [estat-mcp](https://github.com/ajtgjmdjp/estat-mcp) - 日本政府统计数据（e-Stat）

三者共同覆盖日本宏观经济数据的三大官方来源：
- EDINET: 企业财务数据
- e-Stat: 政府统计数据  
- BOJ: 中央银行统计数据