### PR TITLE
add a mcp server based on rust which can read wechat articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [jae-jae/fetcher-mcp](https://github.com/jae-jae/fetcher-mcp)        | 使用 Playwright 无头浏览器获取网页内容，支持 JS 渲染和智能提取 (Markdown/HTML)。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, Playwright 网页内容提取。              |
 | [ryoppippi/sitemcp](https://github.com/ryoppippi/sitemcp)           | 抓取整个网站并将其作为 MCP 服务器使用。                                          | 支持 TypeScript，提供工具命名策略、页面匹配、内容选择器等功能。可通过 NPM、Bun 等安装和运行。 |
 | [34892002/bilibili-mcp-js](https://github.com/34892002/bilibili-mcp-js) | 支持搜索 Bilibili 内容的 MCP 服务器。                                      | 社区实现, TypeScript 开发 📇, 本地运行 🏠.                                        |
-
+| [Zlatanwic/wechat-article-read-mcp](https://github.com/Zlatanwic/Wechat-Read-MCP-in-Rust) |支持微信公众号内容提取，绕过微信反爬机制|  社区实现，rust开发 🦀，本地运行 🏠，高性能，易分发|
 ---
 
 ### 💻 开发与代码执行


### PR DESCRIPTION
一个基于 Rust 实现的 MCP 服务器，用于读取微信公众号文章内容。

通过 headless Chrome 浏览器渲染微信文章页面，提取标题、作者、发布时间和正文内容，以结构化 JSON 格式返回给 AI 客户端（如 Claude Desktop）。


本项目使用Rust实现，优势在于：

🚀 启动速度 — 编译为原生二进制，无需 Python 解释器和虚拟环境，MCP 服务冷启动从数秒降至毫秒级
📦 分发简便 — 单个可执行文件，无需用户安装 Python / pip / venv
💾 内存占用 — Rust 无 GC 开销，整体内存占用更低
🔒 类型安全 — 编译期保证类型正确，杜绝运行时类型错误
⚡ 解析性能 — HTML 解析和文本处理在 Rust 中显著更快