### PR TITLE
添加 Claude Code Open 到 MCP 客户端列表

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
     ![eechat](https://www.ee.chat/img/mcp_chat.png)
   - **Tips**：低门槛适合小白。
 
+- **Claude Code Open**  
+  - **简介**：基于 Claude Code CLI 的开源 AI 编程平台，完整支持 MCP 协议。  
+  - **功能**：支持 MCP 服务器配置与集成，内置 37+ 工具（文件操作、代码分析、Web 访问、系统命令等），提供浏览器端 Web IDE（Monaco 编辑器）、Blueprint 多智能体协作系统、定时任务守护进程。  
+  - **链接**：[GitHub 仓库](https://github.com/kill136/claude-code-open)  
+  - **Tips**：MIT 开源，TypeScript 开发，支持 Windows/macOS/Linux，适合需要 MCP 集成的开发者。
+
 - **其他MCP客户端资源**  
   - [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients)
 


### PR DESCRIPTION
## 描述

添加 [Claude Code Open](https://github.com/kill136/claude-code-open) 到 MCP 客户端列表。

Claude Code Open 是一个基于 Claude Code CLI 的开源 AI 编程平台，完整支持 MCP 协议。主要特性：

- **MCP 协议支持**：完整的 MCP 服务器配置与集成能力
- **37+ 内置工具**：文件操作、代码分析、Web 访问、系统命令等
- **Web IDE**：基于 Monaco 编辑器的浏览器端开发环境
- **多智能体系统**：Blueprint 协作系统，支持复杂多步骤任务
- **跨平台**：支持 Windows、macOS、Linux

**许可证**: MIT  
**语言**: TypeScript  
**GitHub**: https://github.com/kill136/claude-code-open