### PR TITLE
添加 MolTrust MCP 服务器 — 去中心化代理身份与信誉工具包

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [sapientpants/sonarqube-mcp-server](https://github.com/sapientpants/sonarqube-mcp-server) | 与 SonarQube 集成的 MCP 服务器，为 AI 助手提供代码质量指标、问题和质量门状态的访问。                   | 社区实现, Rust 开发 🦀, 云端/本地 ☁️🏠, 代码质量 (SonarQube)。                                   |
 | [securityfortech/secops-mcp](https://github.com/securityfortech/secops-mcp)        | 将流行的开源工具整合到单一 MCP 接口中的一体化安全测试工具箱。连接 AI 代理，实现渗透测试、漏洞赏金、威胁狩猎等任务。 | 社区实现, Python 开发 🐍, 本地运行 🏠, 安全测试工具箱。                                            |
 | [model-audit](https://github.com/liuxiaotong/model-audit) | LLM 蒸馏检测与模型指纹审计 — 文本溯源、身份验证、蒸馏关系判定，守护模型知识产权。 | 社区实现, Python 开发 🐍, 本地运行 🏠, LLM 模型审计与蒸馏检测。 |
-| [MoltyCel/moltrust-mcp-server](https://github.com/MoltyCel/moltrust-mcp-server)   | 去中心化 AI 代理身份与信誉工具包 — DID 创建、信任评分、凭证验证、ERC-8004 链上身份集成。可通过 `pip install moltrust-mcp-server` 安装。 | 社区实现, Python 开发 🐍, 本地运行 🏠, 云服务 ☁️, 代理身份与信誉 (DID/ERC-8004)。 |
+| [MoltyCel/moltrust-mcp-server](https://github.com/MoltyCel/moltrust-mcp-server)   | AI 代理身份、信任与安全工具包 — DID 创建、信任评分、凭证验证、ERC-8004 链上身份，以及 AI 技能安全审计（提示注入检测、数据泄露、范围违规）、代理商务凭证（购物、旅行）、市场完整性监控。27 个工具。`pip install moltrust-mcp-server` | 社区实现, Python 开发 🐍, 本地运行 🏠, 云服务 ☁️, 代理身份与安全 (DID/ERC-8004/技能审计)。 |
 | [Whois MCP](https://github.com/bharathvaj-ganesan/whois-mcp)                     | 对域名、IP、ASN 和 TLD 执行 whois 查询。                                                          | 社区实现, Python 开发, Whois 查询。                                                                |
 
 ---


### PR DESCRIPTION
## 添加内容

在 **🔒 安全与分析** 类别中添加 [MolTrust MCP 服务器](https://github.com/MoltyCel/moltrust-mcp-server)。

## 关于 MolTrust

MolTrust 是一个面向 AI 代理的去中心化身份与信誉工具包，提供 11 个 MCP 工具：

- **DID 创建与解析** — AI 代理的去中心化标识符
- **信任评分** — 查询和验证代理信誉
- **凭证验证** — 可验证凭证的签发与验证
- **ERC-8004 集成** — Base 链上代理身份（以太坊 L2）
- **区块链锚定** — 不可变的身份记录

**安装：** `pip install moltrust-mcp-server` 或 `uvx moltrust-mcp-server`

| | |
|---|---|
| **PyPI** | [moltrust-mcp-server](https://pypi.org/project/moltrust-mcp-server/) |
| **版本** | v0.4.0 |
| **工具数** | 11 |
| **测试数** | 32（全部通过） |
| **语言** | Python |
| **许可证** | MIT |