### PR TITLE
添加 MolTrust MCP 服务器 — AI 代理信任基础设施 (30 工具, v0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [model-audit](https://github.com/liuxiaotong/model-audit) | LLM 蒸馏检测与模型指纹审计 — 文本溯源、身份验证、蒸馏关系判定，守护模型知识产权。 | 社区实现, Python 开发 🐍, 本地运行 🏠, LLM 模型审计与蒸馏检测。 |
 | [Whois MCP](https://github.com/bharathvaj-ganesan/whois-mcp)                     | 对域名、IP、ASN 和 TLD 执行 whois 查询。                                                          | 社区实现, Python 开发, Whois 查询。                                                                |
 | [Wireshark-MCP](https://github.com/bx33661/Wireshark-MCP) | Wireshark 网络数据包分析 MCP 服务器，具有抓包、协议统计、字段提取和安全分析功能。 | 社区实现, Python 开发 🐍, 本地运行 🏠, 网络数据包分析。 |
+| [MolTrust](https://github.com/MoltyCel/moltrust-mcp-server) | AI 代理信任基础设施 — 30 个 MCP 工具，覆盖 W3C DID 身份、信誉评分、女巫攻击检测、可验证凭证签发与验证。支持 6 大场景：身份管理、代理评分、购物代理、旅行代理、技能审计、预测市场。已上线 [MCP Registry](https://registry.modelcontextprotocol.io/)。 | 社区实现, Python 开发 🐍, 云服务 ☁️, `pip install moltrust-mcp-server`, 30 工具 / 63 测试, MIT 许可证。 |
 
 ---
 


### PR DESCRIPTION
## 添加内容

在 **🔒 安全与分析** 类别中添加 [MolTrust MCP 服务器](https://github.com/MoltyCel/moltrust-mcp-server)。

## 关于 MolTrust

MolTrust 是面向 AI 代理经济的**信任基础设施**，提供 **30 个 MCP 工具**，覆盖 6 大场景：

| 场景 | 工具数 | 功能 |
|------|--------|------|
| 🆔 身份管理 | 11 | W3C DID 创建/解析、ERC-8004 链上身份 (Base) |
| 🛡️ 代理评分 | 7 | 信誉评分、女巫攻击检测、审计追踪、市场信号 |
| 🛒 购物代理 | 3 | 购买代理凭证签发与验证 |
| ✈️ 旅行代理 | 3 | 旅行代理凭证、委托链验证 |
| 🔧 技能审计 | 3 | AI 技能安全审计（8 项检测：注入、外泄、权限越界等） |
| 📊 预测市场 | 3 | 钱包-DID 桥接、预测得分、排行榜 |

### 安装

```bash
pip install moltrust-mcp-server
# 或
uvx moltrust-mcp-server
```

| | |
|---|---|
| **PyPI** | [moltrust-mcp-server](https://pypi.org/project/moltrust-mcp-server/) |
| **MCP Registry** | [io.github.MoltyCel/moltrust-mcp-server](https://registry.modelcontextprotocol.io/) |
| **版本** | v0.6.0 |
| **工具数** | 30 |
| **测试数** | 63（全部通过） |
| **许可证** | MIT |
| **网站** | [moltrust.ch](https://moltrust.ch) |