### PR TITLE
Add preflight MCP server to 开发与代码执行 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [ForeverVM](https://github.com/jamsocket/forevervm/tree/main/javascript/mcp-server) | 在代码沙盒中运行 Python 代码。                                                     | 官方实现 (Jamsocket), JavaScript 开发, 代码沙盒。                                   |
 | [Riza](https://github.com/riza-io/riza-mcp)                          | Riza 提供的任意代码执行和工具使用平台。                                              | 官方实现 (Riza), Go 开发, 通用代码执行平台。                                       |
 | [Roundtable](https://github.com/askbudi/roundtable) | 统一AI编程助手的零配置MCP服务器，专为自主代理开发设计，简化多AI工具集成工作流程。 | 社区实现 🌟, Python 开发 🐍, 本地/云端部署 🏠☁️, pip install roundtable-ai |
+| [preflight](https://github.com/preflight-dev/preflight) | 24 个工具的 MCP 服务器，专为 Claude Code 设计：提示词质量评分（12 类评分卡）、模糊指令检测、纠错模式学习、跨服务契约感知、LanceDB 向量会话搜索、Token 成本预估。分析 512 个真实会话发现 30-40% Token 浪费可避免。 | 社区实现 🌟, TypeScript 开发 📇, 本地运行 🏠, npx preflight-dev |
 | [Semgrep](https://github.com/semgrep/mcp)                            | 让 AI 代理使用 Semgrep 进行代码安全扫描。 (Semgrep 官方)                           | 官方实现 (Semgrep) 🎖️, TypeScript 开发 📇, 代码安全扫描 ☁️. (注意: 列表有重复, 一个Py一个TS) |
 | [ZenML](https://github.com/zenml-io/mcp-zenml)                       | 与 ZenML MLOps/LLMOps 平台交互，管理机器学习流程。 (ZenML 官方)                   | 官方实现 (ZenML) 🎖️, Python 开发 🐍, 本地/云端 🏠☁️, MLOps 流程管理。               |
 | [vivekVells/mcp-pandoc](https://github.com/vivekVells/mcp-pandoc)    | 使用 Pandoc 进行无缝文档格式转换（Markdown, HTML, PDF, DOCX, CSV 等）。            | 社区实现, Python 开发 🐍, 本地运行 🏠, 文档格式转换。                                |


### PR DESCRIPTION
## Add preflight

[preflight](https://github.com/preflight-dev/preflight) is a 24-tool MCP server designed for Claude Code that catches ambiguous prompts before they waste tokens.

**Key features:**
- 12-category prompt scoring (ambiguity, scope, context, etc.)
- Correction pattern learning — remembers past mistakes
- Cross-service contract awareness
- Session history search with LanceDB vectors
- Token cost estimation

Built after analyzing 512 real Claude Code sessions (32K+ events, 3,200 prompts) — found 30-40% of tokens wasted on avoidable wrong→fix cycles from vague prompts.

`npx preflight-dev`

Added to the 💻 开发与代码执行 section.