### PR TITLE
Add @rendoc/mcp-server — PDF generation MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [21st.dev Magic](https://github.com/21st-dev/magic-mcp)             | 21st.dev 官方集成，创建受顶级设计工程师启发的精美 UI 组件。                          | 官方实现 (21st.dev) 🎖️, UI 组件创建。                                               |
 | [pydantic/pydantic-ai/mcp-run-python](https://github.com/pydantic/pydantic-ai/tree/main/mcp-run-python) | Pydantic 出品，在安全的沙盒环境中运行 Python 代码，适合开发编程代理。                   | 官方实现 (Pydantic) 🎖️, Python 开发 🐍, 本地运行 🏠, 安全代码执行。                   |
 | [E2B](https://github.com/e2b-dev/mcp-server)                         | 在 E2B 提供的安全云沙盒中运行代码。                                                 | 官方实现 (E2B), TypeScript 开发, 云端安全代码沙盒。                                  |
+| [@rendoc/mcp-server](https://github.com/yoryocoruxo-ai/rendoc) | 通过 MCP 从 HTML 模板和动态数据生成专业 PDF 文档。支持模板管理、实时预览和 API 使用统计。 | 社区实现, TypeScript 开发 📇, 云端 API (rendoc.dev), PDF 生成。 |
 | [JetBrains IDE Proxy](https://github.com/JetBrains/mcpProxy)           | JetBrains 官方代理，连接到 JetBrains IDE。                                       | 官方实现 (JetBrains) 🎖️, TypeScript 开发 📇, 本地运行 🏠, IDE 连接。             |
 | [JetBrains](https://github.com/JetBrains/mcp-jetbrains)              | JetBrains 官方集成，让 AI 在 JetBrains IDE 中处理代码。                               | 官方实现 (JetBrains), Kotlin 开发, IDE 代码操作。                                  |
 | [yepcode/mcp-server-js](https://github.com/yepcode/mcp-server-js)    | 在安全可扩展的沙盒环境中执行 LLM 生成的代码，并用 JS/Python 创建自定义 MCP 工具。 | 官方实现 (YepCode) 🎖️, TypeScript 开发 📇, 云服务 ☁️, 安全代码执行，自定义工具。       |


### PR DESCRIPTION
## 添加 @rendoc/mcp-server

在 **💻 开发与代码执行** 部分添加了 rendoc MCP 服务器。

**rendoc** — 通过 MCP 从 HTML 模板和动态数据生成专业 PDF 文档。

- **npm**: `@rendoc/mcp-server`
- **网站**: [rendoc.dev](https://rendoc.dev)

按照现有表格格式添加。

Ref: #85