### PR TITLE
添加 safari-mcp - macOS 原生 Safari 浏览器自动化

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [ryoppippi/sitemcp](https://github.com/ryoppippi/sitemcp)           | 抓取整个网站并将其作为 MCP 服务器使用。                                          | 支持 TypeScript，提供工具命名策略、页面匹配、内容选择器等功能。可通过 NPM、Bun 等安装和运行。 |
 | [34892002/bilibili-mcp-js](https://github.com/34892002/bilibili-mcp-js) | 支持搜索 Bilibili 内容的 MCP 服务器。                                      | 社区实现, TypeScript 开发 📇, 本地运行 🏠.                                        |
 | [Zlatanwic/wechat-article-read-mcp](https://github.com/Zlatanwic/Wechat-Read-MCP-in-Rust) |支持微信公众号内容提取，绕过微信反爬机制|  社区实现，rust开发 🦀，本地运行 🏠，高性能，易分发|
+| [achiya-automation/safari-mcp](https://github.com/achiya-automation/safari-mcp) | 原生 Safari 浏览器自动化，专为 macOS 设计。通过 AppleScript + JavaScript 提供 80 个工具，零 Chrome 开销，保留登录状态，后台静默运行。 | 社区实现, JavaScript 开发 📇, 本地运行 🏠, macOS 原生 🍎 |
 ---
 
 ### 💻 开发与代码执行


### PR DESCRIPTION
## 添加 safari-mcp 到浏览器自动化与网页交互分类

**项目地址：** https://github.com/achiya-automation/safari-mcp

### 简介

safari-mcp 是专为 macOS 设计的原生 Safari 浏览器自动化 MCP 服务器。

**主要特点：**
- 🍎 **原生 macOS 支持** — 基于 AppleScript + JavaScript，无需 Chrome/Chromium
- 🛠️ **80 个工具** — 覆盖导航、点击、填表、截图、网络监控、Cookie 管理等完整功能
- ⚡ **零开销** — 不需要额外的浏览器进程，直接使用 Safari
- 🔒 **保留登录状态** — 复用 Safari 的 session 和 cookie，无需重复登录
- 🤫 **后台静默运行** — 不影响前台工作

**npm 安装：** `npx -y @anthropic/safari-mcp` 或 `npm i -g @anthropic/safari-mcp`

适用于需要在 macOS 上进行浏览器自动化但不想依赖 Chrome 的开发者。