### PR TITLE
Add newsletter/podcast/recipe commerce MCP servers (内容商品智能提取)

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,6 +865,9 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [zueai/mcp-manager](https://github.com/zueai/mcp-manager)                    | 用于安装和管理 Claude Desktop App 的 MCP 服务器的简单 Web UI。                                      | 社区实现, TypeScript 开发 📇, 云服务 ☁️, MCP 服务器管理 Web UI。                                     |
 | [HenryHaoson/Yuque-MCP-Server](https://github.com/HenryHaoson/Yuque-MCP-Server)  | 用于集成语雀 API 的 MCP 服务器，允许 AI 模型管理文档、与知识库交互、搜索内容和访问语雀平台的分析数据。       | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 语雀 API 集成。                                         |
 | [ttommyth/interactive-mcp](https://github.com/ttommyth/interactive-mcp) | 通过在 MCP 循环中直接添加本地用户提示和聊天功能，实现交互式 LLM 工作流。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 人机交互工作流。 |
+| [newsletter-commerce-mcp](https://github.com/teamsincetoday/newsletter-commerce-mcp) | 从电子邮件和新闻通讯内容中提取产品推荐、赞助商信息和联盟营销机会，帮助内容创作者快速实现商业化变现。支持免费层级（每天 200 次调用）和 $0.01/次付费调用。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 通讯内容商品智能提取, 联盟营销变现。 |
+| [podcast-commerce-mcp](https://github.com/teamsincetoday/podcast-commerce-mcp) | 从播客文字稿中自动提取产品提及和商品推荐，支持品牌识别、置信度评分和联盟营销数据提取。帮助播客创作者快速挖掘内容商业化机会，F1 精度 100%。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 播客商品智能提取, 联盟营销变现。 |
+| [recipe-commerce-mcp](https://github.com/teamsincetoday/recipe-commerce-mcp) | 从菜谱内容中提取食材、厨具和相关商品推荐，支持与联盟营销平台集成，实现食谱内容商业化变现。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 食谱商品提取与变现。 |
 
 ---
 


### PR DESCRIPTION
## 新增 3 个 MCP 服务器 / Adding 3 Content Commerce MCP Servers

### 工具介绍 / Tool Description

这 3 个 MCP 服务器专注于**内容商业化变现**：从播客、新闻通讯和菜谱中自动提取产品推荐和联盟营销机会。

These 3 MCP servers focus on **content commerce**: automatically extracting product recommendations and affiliate marketing opportunities from podcasts, newsletters, and recipes.

| 服务器 | 功能 | GitHub |
|--------|------|--------|
| podcast-commerce-mcp | 从播客文字稿提取商品 | [teamsincetoday/podcast-commerce-mcp](https://github.com/teamsincetoday/podcast-commerce-mcp) |
| newsletter-commerce-mcp | 从通讯内容提取商品 | [teamsincetoday/newsletter-commerce-mcp](https://github.com/teamsincetoday/newsletter-commerce-mcp) |
| recipe-commerce-mcp | 从菜谱内容提取商品 | [teamsincetoday/recipe-commerce-mcp](https://github.com/teamsincetoday/recipe-commerce-mcp) |

### 技术规格 / Technical Specs

- TypeScript 开发，部署在 Cloudflare Workers
- 免费层级：每天 200 次调用（无需 API key）
- 付费层级：$0.01/次，支持 x402 微支付
- F1 精度 100%，643 个自动化测试
- OWASP MCP 安全标准合规

### 放置位置 / Placement

已添加到 **`🛠️ 其他实用工具与集成`** 部分，适合内容创作者和联盟营销工作流。