### PR TITLE
Add Not Human Search - AI Agent 搜索引擎 MCP 服务器

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Multi-Source Media MCP Server (M3S)](https://github.com/Decade-qiu/Multi-Source-Media-MCP-Server) | 多源媒体聚合与生成，统一访问 Unsplash/Pexels、Web 爬取媒体，支持多后端 AI 图像生成以及全网图片爬虫。 | 原生 Go ✨，本地运行 🏠，支持多平台媒体 API 和 AI 图像生成、爬虫扩展。 |
 | [MLT-OSS/FirstData](https://github.com/MLT-OSS/FirstData) | 全球最全面的权威数据源知识库，132+ 经验证数据源（政府、国际组织、学术机构），帮助 AI 减少幻觉。提供结构化元数据、100% URL 验证、中英双语支持。目标：1000+ 数据源。 | 本地/云端 🏠☁️，中国数据源深度覆盖 🇨🇳，AI 事实防线，抗幻觉数据底座。 |
 | [GEOScore](https://github.com/henu-wang/geoscore-mcp) | AI 搜索优化（GEO）MCP 服务器。扫描网站的 AI 搜索就绪度，生成 llms.txt、Schema.org 修复、meta 标签优化。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 支持 Claude/Cursor/Windsurf。 |
+| [Not Human Search](https://nothumansearch.ai) | AI Agent 专用搜索引擎，索引 8,600+ 个 Agent 就绪网站。提供 6 个工具：搜索 Agent 站点、获取站点详情、统计数据、提交站点、注册监控、验证 MCP。安装：`claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp` | 社区实现, Go 开发 🏎️, 云服务 ☁️, Streamable HTTP 传输, 已注册 MCP 官方仓库 ([nothumansearch.ai](https://nothumansearch.ai))。 |
 
 ---
 


### PR DESCRIPTION
## 新增 MCP 服务器

在 🔍 搜索 分类下添加 [Not Human Search](https://nothumansearch.ai)。

**简介：** AI Agent 专用搜索引擎，索引 8,600+ 个 Agent 就绪网站，提供 6 个 MCP 工具。

**功能：**
- `search_agents` - 搜索 Agent 就绪网站
- `get_site_details` - 获取站点详情（GEO 评分、MCP 状态等）
- `get_stats` - 索引统计数据
- `submit_site` - 提交新站点
- `register_monitor` - 注册站点监控
- `verify_mcp` - 实时验证 MCP 端点（JSON-RPC 探测）

**技术：**
- 传输方式：Streamable HTTP（JSON-RPC 2.0）
- 已注册 MCP 官方仓库：`ai.nothumansearch/search` v1.4.0
- 安装：`claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp`

**链接：**
- 网站：https://nothumansearch.ai
- MCP 端点：https://nothumansearch.ai/mcp
- llms.txt：https://nothumansearch.ai/llms.txt