### PR TITLE
Add prompt-to-asset to 多媒体与内容创作

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [anaisbetts/mcp-youtube](https://github.com/anaisbetts/mcp-youtube)              | 获取 YouTube 字幕 (另一版本)。                                                                    | 社区实现, TypeScript 开发 📇, 云服务 ☁️, YouTube 字幕。                                                  |
 | [IDEA-Research/DINO-X-MCP](https://github.com/IDEA-Research/DINO-X-MCP)              |  让 AI 具备细粒度的图像理解能力：识别、定位、描述你看到的任何目标。                                                                     | 官方实现（IDEA-Research）, TypeScript 开发 📇, 本地运行 🏠, 图像识别理解。                                                  |
 | [BibiGPT](https://github.com/JimmyLv/bibigpt-skill) | AI 驱动的视频、音频和播客总结工具，支持 YouTube、Bilibili、TikTok 等平台。提供远程 MCP 服务器 (https://bibigpt.co/api/mcp) 和 Claude Code Skill 两种集成方式。 | 社区实现, 云服务 ☁️, 视频/音频/播客总结。 |
+| [MohamedAbdallah-14/prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) | 将一句话简报路由到 60+ 图像模型中最合适的那个（gpt-image-1.5、Ideogram 3、Recraft V4、Flux、SDXL 等），带有明确的 `Never` 规则以拒绝错误的模型配对（例如 Imagen 无法生成真正的透明 PNG），验证输出（alpha 通道、棋盘格 FFT、ΔE2000 色差、OCR），并分发到 iOS / Android / PWA / favicon / visionOS / Flutter。无需 API key 即可通过 Pollinations、HF Inference、Stable Horde 或宿主 LLM 的内联 SVG 完成。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 云服务 ☁️, 跨平台 🍎🪟🐧, 图像生成路由 + 资产管道。 |
 
 ---
 


### PR DESCRIPTION
Adds [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) to the **多媒体与内容创作** section, at the end of the table.

**工具简介 / What it does:** MCP server + CLI that routes a one-line brief to the right image model across 60+ (gpt-image-1.5, Ideogram 3, Recraft V4, Flux, SDXL, etc.), validates the output, and fans out to iOS / Android / PWA / favicon / visionOS / Flutter bundles.

**差异化 / Differentiator vs other image-gen MCPs in this list (PiAPI, Nova Canvas, Replicate, EverArt):**
- 明确的 `Never` 列 — 拒绝将透明 PNG 请求路由到 Imagen (VAE 仅支持 RGB)、拒绝将长文字商标路由到扩散模型采样器等
- 验证层 (alpha 通道存在性、棋盘格 FFT 签名、ΔE2000 色差、OCR Levenshtein) 捕捉其他工具会默默发布的模型失败
- 三种执行模式 (`inline_svg` / `external_prompt_only` / `api`) 全部可在 \$0 成本下完成 (Pollinations / HF / Stable Horde / 内联 SVG)
- 每条路由规则都引用研究来源

MIT 开源。npm: `prompt-to-asset` (v0.4.5)。

Install with Claude Code: `claude mcp add prompt-to-asset -- npx -y prompt-to-asset`

> 说明：我的中文描述是机器翻译辅助撰写的，如果有更地道的表达方式，欢迎维护者调整。I wrote the Chinese description with translation assistance — feel free to adjust the wording if you prefer a different phrasing.
