### PR TITLE
Add web3-docs to 💰 金融与加密货币

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)                    | x402 支付协议资源目录，包含 MCP 服务器、SDK 和工具，用于基于 HTTP 402 的 USDC 支付（支持 Base、Arbitrum 等 EVM 链）。 | 社区实现, 云服务 ☁️, x402 协议生态资源汇总。                                                         |
 
 ---
+| [dioptx/web3-docs](https://github.com/dioptx/web3-docs) | 本地 MCP 服务器，索引 1,767 条区块链协议规范（EIPs、ERCs、BIPs、SIMDs、Cosmos ADRs、Polkadot RFCs、Stacks SIPs、Avalanche ACPs、Cardano CIPs、Tezos TZIPs、Sui SIPs），覆盖 10 条公链；并附带 19 个 EVM 主流协议的标准合约地址。SQLite + FTS5，无需 API key。 | 社区实现, Python 开发 🐍, 本地运行 🏠, 多链协议规范与合约地址查询。 |
 
 ### 📁 文件系统与存储
 


### PR DESCRIPTION
新增 [**dioptx/web3-docs**](https://github.com/dioptx/web3-docs) 至 **💰 金融与加密货币** 部分。

本地 MCP 服务器，索引 **1,767 条协议规范，覆盖 10 条公链**（EIPs、ERCs、BIPs、SIMDs、Cosmos ADRs、Polkadot RFCs、Stacks SIPs、Avalanche ACPs、Cardano CIPs、Tezos TZIPs、Sui SIPs），并附带 19 个 EVM 主流协议的标准合约地址。SQLite + FTS5 排序检索，毫秒级响应，离线可用，无需 API key。

**特色**: 跨链统一搜索；自动映射以太坊/比特币硬分叉（支持 Pectra ↔ Prague、Dencun ↔ Cancun 等别名）；README 内含三段动图演示。

安装: `uvx --from git+https://github.com/dioptx/web3-docs web3-docs-mcp`，兼容 Claude Code、Cursor、Windsurf、Cline、Zed、Continue、Codex 等任意 MCP 客户端。