### PR TITLE
新增 Muvon/octocode — Rust 语义代码索引器与 GraphRAG MCP 服务器

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [tersePrompts/jarp-mcp](https://github.com/tersePrompts/jarp-mcp) | Java Archive Reader Protocol - 为 AI 代理提供对 Maven 依赖中反编译 Java 代码的即时访问，如同为 AI 装上"X 光透视眼"。 | 社区实现 🌟, Node.js/Java 开发 ☕🟢, 本地运行 🏠, Java 类分析与反编译, CFR 内置, 智能缓存 |
 | [tersePrompts/fastMCP4J](https://github.com/tersePrompts/fastMCP4J) | Java 语言构建 MCP 服务器的轻量级注解驱动框架，JSON Schema 2020-12 兼容，安全、快速、零配置。 | 社区实现 🌟, Java 开发 ☕, 本地运行 🏠, 注解驱动, 12 个依赖, 支持异步、内存、任务、文件操作 |
 | [wopee-mcp](https://www.npmjs.com/package/wopee-mcp) | Web应用AI测试代理，支持调度测试运行、分析爬虫和AI代理测试，获取工件和项目状态。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, AI 测试代理。 |
+| [Muvon/octocode](https://github.com/Muvon/octocode) | Rust 编写的语义代码索引器，构建代码库 GraphRAG 知识图谱并通过 MCP 暴露给 AI 代理。支持 13+ 语言，提供 tree-sitter 解析、ast-grep 结构化搜索和代码签名视图。 | 社区实现, Rust 开发 🦀, 本地运行 🏠, 跨平台 🍎🪟🐧, 语义搜索 + GraphRAG 知识图谱, Apache 2.0。 |
 
 
 ---


### PR DESCRIPTION
新增 **Muvon/octocode** 到「开发与代码执行」分类。

**项目简介:**
Rust 编写的语义代码索引器，构建代码库的 GraphRAG 知识图谱并通过 MCP 服务器暴露给 AI 代理（Claude Desktop / Cursor / Windsurf 等）。

**MCP 工具:**
- `semantic_search` — 自然语言代码语义搜索（基于 LanceDB 向量存储）
- `structural_search` — 基于 ast-grep 的结构化代码搜索，支持原地重写
- `view_signatures` — 仅提取声明（无函数体）以节省 token
- `graphrag` — 代码知识图谱查询（节点关系、路径、概览）

**项目信息:**
- 仓库: https://github.com/Muvon/octocode
- Stars: 335+ • crates.io 下载: 3,449+
- 支持语言: Rust, Python, JS/TS, Go, C++, PHP, Ruby, Java, Lua, Bash, CSS, JSON, Svelte, Markdown (共 13+)
- 协议: Apache 2.0
- 本地优先（local-first）, 遵循 .gitignore
- Voyage AI 嵌入模型免费额度 200M tokens/月
