### PR TITLE
添加 olo-dot-io/Uni-CLI 到命令行与 Shell 交互

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [OthmaneBlial/term_mcp_deepseek](https://github.com/OthmaneBlial/term_mcp_deepseek) | 用于终端的 DeepSeek 类 MCP 服务器。                                                | 社区实现, Python 开发 🐍, 本地运行 🏠, 终端交互。                                         |
 | [tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server)    | 实现模型上下文协议 (MCP) 的安全 Shell 命令执行服务器。                                   | 社区实现, Python 开发, 安全 Shell 执行。                                                  |
 | [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) | 多功能工具，可管理/执行程序，读/写/搜索/编辑代码和文本文件。(也含代码/文件功能)             | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, 命令行/文件/程序管理。          |
-| [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) | 自修复 CLI 目录，将 237+ 网站、桌面应用、外部 CLI 通过一个 MCP 服务器暴露给 AI 代理；920 个 YAML 适配器，结构化错误信封让代理在调用失败时直接编辑 YAML 并重试。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, Apache-2.0, 3,319 命令, 中位数 ~80 tokens/调用。 |
+| [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) | 自修复 CLI 目录，将 238 个网站、桌面应用、外部 CLI 通过一个 MCP 服务器暴露给 AI 代理；声明式 YAML 适配器加结构化错误信封，代理在调用失败时直接编辑 YAML 并重试。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, Apache-2.0, 1,458 命令；每次调用 token 预算见 [`docs/BENCHMARK.md`](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/BENCHMARK.md)。 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [OthmaneBlial/term_mcp_deepseek](https://github.com/OthmaneBlial/term_mcp_deepseek) | 用于终端的 DeepSeek 类 MCP 服务器。                                                | 社区实现, Python 开发 🐍, 本地运行 🏠, 终端交互。                                         |
 | [tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server)    | 实现模型上下文协议 (MCP) 的安全 Shell 命令执行服务器。                                   | 社区实现, Python 开发, 安全 Shell 执行。                                                  |
 | [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) | 多功能工具，可管理/执行程序，读/写/搜索/编辑代码和文本文件。(也含代码/文件功能)             | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, 命令行/文件/程序管理。          |
+| [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) | 自修复 CLI 目录，将 237+ 网站、桌面应用、外部 CLI 通过一个 MCP 服务器暴露给 AI 代理；920 个 YAML 适配器，结构化错误信封让代理在调用失败时直接编辑 YAML 并重试。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, Apache-2.0, 3,319 命令, 中位数 ~80 tokens/调用。 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [OthmaneBlial/term_mcp_deepseek](https://github.com/OthmaneBlial/term_mcp_deepseek) | 用于终端的 DeepSeek 类 MCP 服务器。                                                | 社区实现, Python 开发 🐍, 本地运行 🏠, 终端交互。                                         |
 | [tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server)    | 实现模型上下文协议 (MCP) 的安全 Shell 命令执行服务器。                                   | 社区实现, Python 开发, 安全 Shell 执行。                                                  |
 | [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) | 多功能工具，可管理/执行程序，读/写/搜索/编辑代码和文本文件。(也含代码/文件功能)             | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, 命令行/文件/程序管理。          |
-| [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) | 自修复 CLI 目录，将 238 个网站、桌面应用、外部 CLI 通过一个 MCP 服务器暴露给 AI 代理；声明式 YAML 适配器加结构化错误信封，代理在调用失败时直接编辑 YAML 并重试。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, Apache-2.0, 1,458 命令；每次调用 token 预算见 [`docs/BENCHMARK.md`](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/BENCHMARK.md)。 |
+| [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) | 自修复 CLI 目录，将网页、桌面应用、Electron 应用、外部 CLI 作为确定性命令通过一个 MCP 服务器暴露给 AI 代理；声明式 YAML 适配器加结构化错误信封，调用失败时代理可直接编辑 YAML 并重试。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, Apache-2.0；目录规模与每次调用 token 预算见仓库 [README](https://github.com/olo-dot-io/Uni-CLI#readme) 与 [`docs/BENCHMARK.md`](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/BENCHMARK.md)。 |
 
 ---
 


### PR DESCRIPTION
## 添加内容
在 **🖥️ 命令行与 Shell 交互** 表格末尾添加 [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)。

## 项目简介
Uni-CLI 是一个 **自修复 CLI 目录**，把 237+ 网站、桌面应用、外部 CLI 通过一个 MCP 服务器（stdio + Streamable HTTP）暴露给 AI 代理。底层是 920 个声明式 YAML 适配器 + 216 个 TS 适配器，共 3,319 条命令。

**差异化能力**：每个错误响应都是结构化信封（`code`、`adapter_path`、`step`、`suggestion`、`retryable`、`alternatives`）。当目标网站换 selector 或 auth 时，代理直接编辑 `adapter_path` 处的 YAML 并重试，无需人工介入。中位数约 ~80 tokens/调用。

## 格式
- 表格行格式与上下文一致：名称 | 中文介绍 | 备注。
- 备注包含：实现类型、语言、运行位置、平台、许可证、命令数、token 成本。

## 项目信号
- Apache-2.0，TypeScript 严格模式，Node ≥ 20。
- npm: [`@zenalexa/unicli`](https://www.npmjs.com/package/@zenalexa/unicli)。
- 最新版本：v0.218.0（2026-05-05）。
- 文档：https://olo-dot-io.github.io/Uni-CLI/