### PR TITLE
Refresh Xquik social MCP listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [team-telnyx/telnyx-mcp-server](https://github.com/team-telnyx/telnyx-mcp-server) | Telnyx 官方 MCP 服务器，用于构建 AI 驱动的通信应用。创建语音助手、发送短信、管理电话号码、集成实时消息。 | 官方实现 (Telnyx) 🎖️, Python 开发 🐍, 云服务 ☁️, 电话/短信/AI 语音助手。 |
 | [userad/didlogic_mcp](https://github.com/UserAd/didlogic_mcp)          | DIDLogic MCP 服务器。增加管理 SIP 端点、号码和目的地的功能。                              | 社区实现, Python 开发 🐍, 云服务 ☁️, DIDLogic (VoIP) 集成。                               |
 | [X (Twitter) (by vidhupv)](https://github.com/vidhupv/x-mcp)         | 直接通过 Claude 创建、管理和发布 X/Twitter 推文。                                            | 社区实现, Python 开发, Twitter 发推管理。                                                 |
-| [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) | X/Twitter 数据平台 — MCP 服务器（StreamableHTTP 传输），76 个 REST API 端点，20 个批量提取工具，账户监控，抽奖系统。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, X/Twitter 数据提取与分析。 |
+| [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) | X/Twitter MCP/API 平台：支持推文搜索、用户查询、粉丝导出、媒体上传/下载、账户监控、Webhooks、抽奖，以及发推/回复自动化。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, REST API + MCP；OpenClaw 可用 [TweetClaw](https://github.com/Xquik-dev/tweetclaw) 插件。 |
 | [VibeMarketing](https://vibemarketing.ninja/mcp) | X/Twitter 和 LinkedIn 社交媒体调度工具，支持 AI 驱动的内容生成。OAuth 身份验证，计划发布，账户管理，订阅跟踪。 | 远程 MCP 服务器 ☁️，社交媒体营销自动化。 |
 | [Google Tasks (by zcaceres)](https://github.com/zcaceres/gtasks-mcp)   | Google Tasks API 服务器。                                                                   | 社区实现, TypeScript 开发 📇, 云服务 ☁️, Google Tasks 管理 (TS)。                        |
 


### PR DESCRIPTION
## Summary

- Refresh the existing Xquik MCP row with current X/Twitter jobs: tweet search, user lookup, follower export, media workflows, monitors, webhooks, giveaway draws, and tweet/reply automation.
- Add the related TweetClaw OpenClaw plugin link in the notes column for OpenClaw users who want the same Xquik workflow through plugin tools.

## Checks

- Read README, license, repo metadata, open PRs, closed Xquik PR history, issue state, and duplicate terms.
- Confirmed there is no open duplicate Xquik/TweetClaw PR or issue.
- Ran `git diff --check`.
- Verified both GitHub links return HTTP 200.
