### PR TITLE
Add dakera-ai/dakera-mcp — self-hosted MCP-native agent memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Rememberizer AI](https://github.com/skydeckai/mcp-server-rememberizer)            | 与 Rememberizer 数据源交互，促进增强的知识检索。                                                                 | 社区实现, Python 开发, 知识检索。                                                                 |
 | [topoteretes/cognee](https://github.com/topoteretes/cognee/tree/dev/cognee-mcp)     | 使用各种图和向量存储的 AI 应用和 Agents 记忆管理器，允许从 30+ 数据源摄取。 (cognee-mcp 的开发分支)              | 社区实现, TypeScript 开发 📇, 本地运行 🏠, GraphRAG 记忆 (更通用)。                                  |
 | [unibaseio/membase-mcp](https://github.com/unibaseio/membase-mcp)                  | 通过 Membase 以分布式方式保存和查询你的 Agent 记忆。                                                     | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 分布式 Agent 记忆。                                      |
+| [dakera-ai/dakera-mcp](https://github.com/dakera-ai/dakera-mcp)                   | 自托管 MCP 原生 Agent 记忆服务器。83 个 MCP 工具，支持衰减加权的情节记忆跨会话持久化。RocksDB + HNSW 向量搜索后端，LoCoMo 基准测试得分 87.8%，多 SDK 支持（Python/JS/Rust/Go），Docker Compose 一键部署。 | 社区实现, Rust 开发 🦀, 本地运行 🏠, 衰减加权持久记忆。                                          |
 
 ---
 


### PR DESCRIPTION
## 添加 dakera-ai/dakera-mcp

**[dakera-mcp](https://github.com/dakera-ai/dakera-mcp)** 是一款完全自托管的 MCP 原生 Agent 记忆服务器，适合放入「🧠 知识、记忆与 RAG」分类。

### 核心特性：
- **83 个 MCP 工具**，覆盖记忆存储、召回、会话管理、命名空间、衰减配置等
- **衰减加权向量召回** — 记忆重要性随时间自然衰减，模拟人类记忆机制
- **RocksDB + HNSW** 双引擎持久化，支持高并发向量检索
- **LoCoMo 基准测试 87.8%**，在开源 Agent 记忆方案中排名前列
- **多 SDK 支持**：Python、JavaScript、Rust、Go 官方客户端
- **Docker Compose 一键部署**，含 MinIO 对象存储 + Prometheus 监控
- **完全本地运行**，数据主权完全自主，无需云端

### 许可证
Apache-2.0

适合关注 AI Agent 长期记忆、RAG 知识库、私有部署场景的中文开发者。