### PR TITLE
添加 SolvoHQ/jsontosdk-mcp — JSON 样本生成 TypeScript SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [tersePrompts/jarp-mcp](https://github.com/tersePrompts/jarp-mcp) | Java Archive Reader Protocol - 为 AI 代理提供对 Maven 依赖中反编译 Java 代码的即时访问，如同为 AI 装上"X 光透视眼"。 | 社区实现 🌟, Node.js/Java 开发 ☕🟢, 本地运行 🏠, Java 类分析与反编译, CFR 内置, 智能缓存 |
 | [tersePrompts/fastMCP4J](https://github.com/tersePrompts/fastMCP4J) | Java 语言构建 MCP 服务器的轻量级注解驱动框架，JSON Schema 2020-12 兼容，安全、快速、零配置。 | 社区实现 🌟, Java 开发 ☕, 本地运行 🏠, 注解驱动, 12 个依赖, 支持异步、内存、任务、文件操作 |
 | [wopee-mcp](https://www.npmjs.com/package/wopee-mcp) | Web应用AI测试代理，支持调度测试运行、分析爬虫和AI代理测试，获取工件和项目状态。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, AI 测试代理。 |
+| [SolvoHQ/jsontosdk-mcp](https://github.com/SolvoHQ/jsontosdk-mcp) | 将任意 JSON 样本一步转换为类型化的 TypeScript SDK——包含 Zod schema、fetch 辅助函数和由 LLM 命名的 interface。封装 jsontosdk.vercel.app 的 `/api/generate` 端点为单一 stdio 工具。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, JSON → TS SDK 代码生成。 |
 
 
 ---


### PR DESCRIPTION
将 [SolvoHQ/jsontosdk-mcp](https://github.com/SolvoHQ/jsontosdk-mcp) 添加到 **💻 开发与代码执行** 分类。

这是一个把 JSON 样本（例如某个第三方 API 的响应）一步转换为类型化 TypeScript SDK 的 MCP 服务器——同时生成 Zod schema、fetch 辅助函数、由 LLM 命名的 interface。封装了 `jsontosdk.vercel.app` 的 `/api/generate` 端点为单一 stdio 工具。

安装非常简单（任何 MCP 客户端均支持）：
```json
{
  "mcpServers": {
    "jsontosdk": {
      "command": "npx",
      "args": ["-y", "github:SolvoHQ/jsontosdk-mcp"]
    }
  }
}
```

跟分类里已有的 `yWorks/mcp-typescribe`（TS API 信息）、`Lstmxx/yapi-mcp-server`（Yapi → TS）相邻，方向相反——JSON → 类型化 SDK。