### PR TITLE
更新 Xquik MCP 列表信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [team-telnyx/telnyx-mcp-server](https://github.com/team-telnyx/telnyx-mcp-server) | Telnyx 官方 MCP 服务器，用于构建 AI 驱动的通信应用。创建语音助手、发送短信、管理电话号码、集成实时消息。 | 官方实现 (Telnyx) 🎖️, Python 开发 🐍, 云服务 ☁️, 电话/短信/AI 语音助手。 |
 | [userad/didlogic_mcp](https://github.com/UserAd/didlogic_mcp)          | DIDLogic MCP 服务器。增加管理 SIP 端点、号码和目的地的功能。                              | 社区实现, Python 开发 🐍, 云服务 ☁️, DIDLogic (VoIP) 集成。                               |
 | [X (Twitter) (by vidhupv)](https://github.com/vidhupv/x-mcp)         | 直接通过 Claude 创建、管理和发布 X/Twitter 推文。                                            | 社区实现, Python 开发, Twitter 发推管理。                                                 |
-| [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) | X/Twitter 数据平台 — MCP 服务器（StreamableHTTP 传输），76 个 REST API 端点，20 个批量提取工具，账户监控，抽奖系统。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, X/Twitter 数据提取与分析。 |
+| [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) | X/Twitter 数据平台，提供 Streamable HTTP MCP 服务、100+ REST API 端点、23 类批量提取、账户监控与 HMAC Webhook。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, X/Twitter 数据提取与自动化。 |
 | [VibeMarketing](https://vibemarketing.ninja/mcp) | X/Twitter 和 LinkedIn 社交媒体调度工具，支持 AI 驱动的内容生成。OAuth 身份验证，计划发布，账户管理，订阅跟踪。 | 远程 MCP 服务器 ☁️，社交媒体营销自动化。 |
 | [Google Tasks (by zcaceres)](https://github.com/zcaceres/gtasks-mcp)   | Google Tasks API 服务器。                                                                   | 社区实现, TypeScript 开发 📇, 云服务 ☁️, Google Tasks 管理 (TS)。                        |
 


### PR DESCRIPTION
## Summary

- 更新现有 Xquik 条目的能力摘要。
- 将过期的 76 个 REST API 端点和 20 个批量提取工具改为当前公开说明中的 100+ REST API 端点、2 个 MCP tools、23 类批量提取和 HMAC Webhook。

## Checks

- 已确认 README 已有 Xquik 条目，所以只更新现有行，不新增重复条目。
- 已检查 open/closed PR 和 issue，没有发现 Xquik 重复更新。
- git diff --check
- Xquik repo link check returns 200.
