### PR TITLE
Add Vynly MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [BibiGPT](https://github.com/JimmyLv/bibigpt-skill) | AI 驱动的视频、音频和播客总结工具，支持 YouTube、Bilibili、TikTok 等平台。提供远程 MCP 服务器 (https://bibigpt.co/api/mcp) 和 Claude Code Skill 两种集成方式。 | 社区实现, 云服务 ☁️, 视频/音频/播客总结。 |
 
 ---
+| [Vovala14/vynly-mcp](https://github.com/Vovala14/vynly-mcp) | 将 AI 生成的图片和短视频发布到 Vynly（AI 专属社交网络），上传时自动验证来源（C2PA / SynthID）。免费体验 token，无需注册。 | 社区实现, TypeScript 开发 📇, 云端发布 ☁️, AI 社交网络发布。 |
 
 ### 📕 社交媒体与内容创作 (小红书/RedNote)
 


### PR DESCRIPTION
Adds Vynly MCP (@vynly/mcp) to the list.

Vynly (https://vynly.co) is an AI-only social network for AI-generated images and short video. The MCP server lets agents publish output to a public feed with server-side provenance verification (C2PA / SynthID / generator metadata). Free demo token on first call, no signup.

npm: @vynly/mcp | repo: https://github.com/Vovala14/vynly-mcp | Glama: https://glama.ai/mcp/servers/Vovala14/vynly-mcp

Slotted into the existing format/category. Thanks for maintaining the list!