### PR TITLE
feat: 加入 misp-mcp-server — MISP 威胁情报 MCP，内建提示注入防御

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,6 +796,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Whois MCP](https://github.com/bharathvaj-ganesan/whois-mcp)                     | 对域名、IP、ASN 和 TLD 执行 whois 查询。                                                          | 社区实现, Python 开发, Whois 查询。                                                                |
 | [Wireshark-MCP](https://github.com/bx33661/Wireshark-MCP) | Wireshark 网络数据包分析 MCP 服务器，具有抓包、协议统计、字段提取和安全分析功能。 | 社区实现, Python 开发 🐍, 本地运行 🏠, 网络数据包分析。 |
 | [AgentShield](https://github.com/elliotllliu/agent-shield) | AI Agent 技能、MCP 服务器和插件安全扫描器。30 条检测规则，支持 AST 污点追踪、跨文件数据流分析、杀伤链检测、8 语言提示注入检测（中/日/韩/俄/阿/西/法/德）。零安装 (npx)，100% 离线运行。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, AI Agent 安全扫描。 |
+| [misp-mcp-server](https://github.com/ppcvote/misp-mcp-server) | 將 MISP（Malware Information Sharing Platform）威脅情報平台封裝為 MCP 唯讀工具，內建提示注入防禦。每次 MISP 回應都會經過 [prompt-defense-audit](https://github.com/ppcvote/prompt-defense-audit) 的 `scanOutput()` 掃描，過濾掉聯邦化情報來源可能被植入的對抗性 payload。8 個唯讀工具（events / attributes / search / tags / feeds / galaxies）。對應 MISP 官方 issue [MISP/MISP#10745](https://github.com/MISP/MISP/issues/10745)。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, MISP 威胁情报与提示注入防御。 |
 
 ---
 


### PR DESCRIPTION
将 [`ppcvote/misp-mcp-server`](https://github.com/ppcvote/misp-mcp-server) 加入 **🔒 安全与分析** 区段。

## 是什么

将 MISP (Malware Information Sharing Platform) 威胁情报平台封装为 MCP 唯读工具，让 LLM agent 可以查询 events / attributes / search / tags / feeds / galaxies — 共 8 个唯读工具。

## 为什么值得收录

SOC 分析师已经在用 Claude / Cursor 做 triage。但 MCP server 把 LLM 连到威胁情报平台时有一个未被充分讨论的攻击面：**对抗性投毒（adversarial seeding）**。能向 MISP 提交属性（直接或透过联邦化 feed）的攻击者，可以植入提示注入 payload 来劫持下游读取这些属性的 LLM agent。

本 server 把 [`prompt-defense-audit`](https://github.com/ppcvote/prompt-defense-audit) 的 `scanOutput()` 直接焊在每个回应上，过滤已知的高危 pattern（script tag / JS URL / shell injection / 已知 PI 签名）后才送到 LLM。**全部唯读**，不暴露任何写入工具，因为让 LLM 写入威胁情报平台本身就是供应链妥协向量。

对应 MISP 官方 issue [MISP/MISP#10745](https://github.com/MISP/MISP/issues/10745)（MISP 团队提出的 MCP server 需求）。MIT 授权。