### PR TITLE
Add Doxa MCP to Art & Culture (基督教鼓励与圣经查询)

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,6 +852,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [r-huijts/rijksmuseum-mcp](https://github.com/r-huijts/rijksmuseum-mcp) | Rijksmuseum API 集成，用于艺术品搜索、详情和收藏。                                                    | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 荷兰国立博物馆艺术品。                               |
 | [r-huijts/oorlogsbronnen-mcp](https://github.com/r-huijts/oorlogsbronnen-mcp) | Oorlogsbronnen (战争来源) API 集成，访问荷兰二战时期 (1940-1945) 的历史记录、照片和文件。                  | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 荷兰二战历史资料。                                 |
 | [yuna0x0/anilist-mcp](https://github.com/yuna0x0/anilist-mcp)          | 集成 AniList API 的 MCP 服务器，用于动漫和漫画信息。                                                  | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 动漫/漫画信息 (AniList)。                           |
+| [The-Doxa-Way/doxa-mcp-schema](https://github.com/The-Doxa-Way/doxa-mcp-schema) | 提供基督教鼓励与圣经查询的免费托管 MCP 服务器，内置三个工具，均以公有领域的 Berean Standard Bible 为依据：鼓励、圣经经文查询（带深链）、Doxa Way 旅程指引。 | 社区实现, 云服务 ☁️, 远程 Streamable HTTP (https://doxa.app/mcp/v1), 圣经经文查询与基督教鼓励, 可选自带授权 (BYOL)。 |
 
 ---
 


### PR DESCRIPTION
## Add Doxa MCP

This PR adds one row for Doxa MCP to the Art & Culture (艺术与文化) table in `README.md`. The format matches the existing entries (name link, Chinese description, tags), placed after the last row in that table.

Doxa MCP is a free hosted, remote (streamable HTTP) Model Context Protocol server for Christian encouragement and Bible lookup, usable from Claude Desktop, Cursor, Cline, LibreChat, and any MCP client.

- Endpoint: https://doxa.app/mcp/v1
- Landing page: https://doxa.app/mcp
- Schema repo: https://github.com/The-Doxa-Way/doxa-mcp-schema
- npm client: @thedoxaway/mcp-client

Three tools, all grounded in the Berean Standard Bible (public domain):

- `doxa_encourage`: Scripture-grounded encouragement
- `doxa_scripture`: BSB verse lookup with deep links
- `doxa_way_movement`: guidance through the Doxa Way

Install snippet (add to the client config):

```json
{"mcpServers":{"doxa":{"command":"npx","args":["-y","mcp-remote","https://doxa.app/mcp/v1"]}}}
```

The free hosted tier needs no credentials; bring your own licence (one header) unlocks unlimited use. It is the only Christian MCP publishing a public 5/5 pass on the independent faith.tools Christian-AI safety rubric, including crisis handling.

Only `README.md` changed; the new row appears once and matches the surrounding table format.
