### PR TITLE
feat: 新增 The Stall — 173 工具 x402 按调用付费 MCP 能力底盘

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [SaintDoresh/YFinance-Trader-MCP-ClaudeDesktop](https://github.com/SaintDoresh/YFinance-Trader-MCP-ClaudeDesktop.git) | 使用 Yahoo Finance API 提供股市数据和分析的 MCP 工具。                                          | 社区实现, Python 开发 🐍, 云服务 ☁️, Yahoo Finance 数据分析。                                       |
 | [Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server) | 使用 Solana Agent Kit 与 Solana 区块链交互，支持 40+ 协议操作。                                        | 社区实现, TypeScript 开发, Solana 链交互。                                                         |
 | [AlphaVantage](https://github.com/calvernaz/alphavantage)                          | AlphaVantage 股票市场数据 API 服务器。                                                              | 社区实现, Python 开发, AlphaVantage 金融数据。                                                      |
-| [The Stall](https://github.com/thebrierfox/the-stall) | 基于 x402 协议的按调用付费 MCP 能力底盘，173 个工具覆盖金融、加密货币、DeFi、宏观数据及链上情报，以 USDC 在 Base 主网结算，无需 API 密钥。 | 社区实现 (IntuiTek¹), TypeScript 开发 📇, 云服务 ☁️, x402 USDC 按调用付费，173 工具。 |
+| [The Stall](https://github.com/thebrierfox/the-stall) | 基于 x402 协议的按调用付费 MCP 能力底盘，172 个工具覆盖金融、加密货币、DeFi、宏观数据及链上情报，以 USDC 在 Base 主网结算，无需 API 密钥。 | 社区实现 (IntuiTek¹), TypeScript 开发 📇, 云服务 ☁️, x402 USDC 按调用付费，172 工具。 |
 | [xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)                    | x402 支付协议资源目录，包含 MCP 服务器、SDK 和工具，用于基于 HTTP 402 的 USDC 支付（支持 Base、Arbitrum 等 EVM 链）。 | 社区实现, 云服务 ☁️, x402 协议生态资源汇总。                                                         |
 
 ---

--- a/README.md
+++ b/README.md
@@ -577,6 +577,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [SaintDoresh/YFinance-Trader-MCP-ClaudeDesktop](https://github.com/SaintDoresh/YFinance-Trader-MCP-ClaudeDesktop.git) | 使用 Yahoo Finance API 提供股市数据和分析的 MCP 工具。                                          | 社区实现, Python 开发 🐍, 云服务 ☁️, Yahoo Finance 数据分析。                                       |
 | [Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server) | 使用 Solana Agent Kit 与 Solana 区块链交互，支持 40+ 协议操作。                                        | 社区实现, TypeScript 开发, Solana 链交互。                                                         |
 | [AlphaVantage](https://github.com/calvernaz/alphavantage)                          | AlphaVantage 股票市场数据 API 服务器。                                                              | 社区实现, Python 开发, AlphaVantage 金融数据。                                                      |
+| [The Stall](https://github.com/thebrierfox/the-stall) | 基于 x402 协议的按调用付费 MCP 能力底盘，173 个工具覆盖金融、加密货币、DeFi、宏观数据及链上情报，以 USDC 在 Base 主网结算，无需 API 密钥。 | 社区实现 (IntuiTek¹), TypeScript 开发 📇, 云服务 ☁️, x402 USDC 按调用付费，173 工具。 |
 | [xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)                    | x402 支付协议资源目录，包含 MCP 服务器、SDK 和工具，用于基于 HTTP 402 的 USDC 支付（支持 Base、Arbitrum 等 EVM 链）。 | 社区实现, 云服务 ☁️, x402 协议生态资源汇总。                                                         |
 
 ---


### PR DESCRIPTION
## 新增 The Stall — x402 MCP 按调用付费能力底盘

**分类：** 💰 金融与加密货币

[The Stall](https://github.com/thebrierfox/the-stall) 是基于 x402 协议的按调用付费 MCP 能力底盘，173 个工具覆盖：

- 📈 **金融与宏观**：美股实时价格、期权链、期货、国债收益率、盈利日历、内幕交易
- 🪙 **加密货币与 DeFi**：DEX 报价、DeFi 收益、鲸鱼追踪、链上钱包分析、Solana 代币风险
- 🔍 **Web 情报**：公司尽调、新闻情绪分析、替代数据（PMI、劳动力、大宗商品）

**核心特点：**
- 无需 API 密钥 — 直接调用，USDC 在 Base 主网结算（x402 协议）
- 价格透明 — $0.001–$1.50/次
- 单一服务器涵盖 173 个实时数据工具

接入方式：
```json
{"mcpServers":{"the-stall":{"command":"npx","args":["-y","mcp-remote","https://the-stall.intuitek.ai/mcp"]}}}
```

*x402 协议为 Base/Coinbase 推动的 HTTP 402 USDC 机器对机器支付标准，已有 4.2M+ 次结算记录。*