### PR TITLE
feat: The Stall — 210 pay-per-call AI capabilities via x402 MCP (v4.64.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server) | 使用 Solana Agent Kit 与 Solana 区块链交互，支持 40+ 协议操作。                                        | 社区实现, TypeScript 开发, Solana 链交互。                                                         |
 | [AlphaVantage](https://github.com/calvernaz/alphavantage)                          | AlphaVantage 股票市场数据 API 服务器。                                                              | 社区实现, Python 开发, AlphaVantage 金融数据。                                                      |
 | [xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)                    | x402 支付协议资源目录，包含 MCP 服务器、SDK 和工具，用于基于 HTTP 402 的 USDC 支付（支持 Base、Arbitrum 等 EVM 链）。 | 社区实现, 云服务 ☁️, x402 协议生态资源汇总。                                                         |
+| [thebrierfox/the-stall](https://github.com/thebrierfox/the-stall)                | 183个按调用付费的AI金融数据工具，覆盖美股（实时股价/期权链/收益日历）、加密货币、DeFi（TVL/协议收益）、宏观经济、合规筛查、全球新闻情绪分析等。无需API密钥，使用Base链USDC微支付（x402协议）。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 183个x402微支付数据工具，无需API密钥。                          |
 
 ---
 


### PR DESCRIPTION
## The Stall — 209 pay-per-call AI capabilities (v4.63.1)

**Live:** https://the-stall.intuitek.ai | **MCP:** https://the-stall.intuitek.ai/mcp

The Stall is an x402 MCP server with 209 pay-per-call capabilities — AI agents pay USDC per call, no API keys needed.

**Coverage:** stocks, crypto, DeFi, insider trades, Form 144 planned sales, options, macro, congressional trades, weather, cron tools, domain intel, and more.

**Recent additions (v4.63.1):**
- `twitter-intel` — real-time X/Twitter post and user data via x402 proxy
- `meme-radar` — Solana meme coin quality/volume radar via DexScreener
- `form-144-intel` — SEC Form 144 planned insider sale filings (pre-Form 4 signal)
- `cron-parser` — parse cron expressions, return next N run times

```json
{
  "mcpServers": {
    "the-stall": {
      "type": "streamable-http",
      "url": "https://the-stall.intuitek.ai/mcp"
    }
  }
}
```

git: a8ccfc4 | version: v4.63.1 | caps: 209