### PR TITLE
Add BuyWhere MCP to 搜索 section - SG/SEA product price comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Multi-Source Media MCP Server (M3S)](https://github.com/Decade-qiu/Multi-Source-Media-MCP-Server) | 多源媒体聚合与生成，统一访问 Unsplash/Pexels、Web 爬取媒体，支持多后端 AI 图像生成以及全网图片爬虫。 | 原生 Go ✨，本地运行 🏠，支持多平台媒体 API 和 AI 图像生成、爬虫扩展。 |
 | [MLT-OSS/FirstData](https://github.com/MLT-OSS/FirstData) | 全球最全面的权威数据源知识库，132+ 经验证数据源（政府、国际组织、学术机构），帮助 AI 减少幻觉。提供结构化元数据、100% URL 验证、中英双语支持。目标：1000+ 数据源。 | 本地/云端 🏠☁️，中国数据源深度覆盖 🇨🇳，AI 事实防线，抗幻觉数据底座。 |
 | [GEOScore](https://github.com/henu-wang/geoscore-mcp) | AI 搜索优化（GEO）MCP 服务器。扫描网站的 AI 搜索就绪度，生成 llms.txt、Schema.org 修复、meta 标签优化。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 支持 Claude/Cursor/Windsurf。 |
+| [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) | 面向新加坡及东南亚的跨平台商品比价 MCP，AI 代理可跨 Lazada、Shopee、Qoo10 等主流电商搜索和比较商品价格，覆盖 5000 万+ 商品，支持 npm `@buywhere/mcp-server`。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 东南亚跨平台商品价格比较。 |
 
 ---
 


### PR DESCRIPTION
## 添加 BuyWhere 到搜索分类 / Add BuyWhere to Search section

**BuyWhere** 是面向新加坡及东南亚市场的跨平台商品比价 MCP 服务，让 AI 代理能够一键搜索和比较 Lazada、Shopee、Qoo10 等主流平台的商品价格。

**BuyWhere** is a cross-platform product search and price comparison MCP server for Singapore and Southeast Asia. It enables AI agents to search and compare prices across Lazada, Shopee, Qoo10, and other major regional platforms.

**Details:**
- 5000万+ 商品 / 50M+ products across 6 markets (SG, MY, TH, ID, PH, US)
- npm: `@buywhere/mcp-server`
- GitHub: https://github.com/BuyWhere/buywhere-mcp
- Website: https://buywhere.ai
- MCP endpoint: `https://api.buywhere.ai/mcp`

**Quick start:**
```bash
npx @buywhere/mcp-server
```