### PR TITLE
Add BuyWhere MCP server — real-time SEA product search & price comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Aas-ee/open-webSearch](https://github.com/Aas-ee/open-webSearch)           | 一个基于多引擎搜索结果的模型上下文协议(MCP)服务器，支持免费网络搜索，无需API密钥。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 云服务 ☁️ , 支持 Bing, Baidu, DuckDuckGo, Brave, Exa, Github, and CSDN.                            |
 | [Multi-Source Media MCP Server (M3S)](https://github.com/Decade-qiu/Multi-Source-Media-MCP-Server) | 多源媒体聚合与生成，统一访问 Unsplash/Pexels、Web 爬取媒体，支持多后端 AI 图像生成以及全网图片爬虫。 | 原生 Go ✨，本地运行 🏠，支持多平台媒体 API 和 AI 图像生成、爬虫扩展。 |
 | [MLT-OSS/FirstData](https://github.com/MLT-OSS/FirstData) | 全球最全面的权威数据源知识库，132+ 经验证数据源（政府、国际组织、学术机构），帮助 AI 减少幻觉。提供结构化元数据、100% URL 验证、中英双语支持。目标：1000+ 数据源。 | 本地/云端 🏠☁️，中国数据源深度覆盖 🇨🇳，AI 事实防线，抗幻觉数据底座。 |
+| [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) | 新加坡及东南亚实时商品搜索与比价 MCP 服务器。覆盖 Lazada、Shopee、FairPrice 等 260,000+ 商品，支持多商家价格比较，查找最低价。 | 官方实现 (BuyWhere) 🎖️, TypeScript 开发 📇, 云服务 ☁️, 东南亚电商商品搜索。 |
 | [GEOScore](https://github.com/henu-wang/geoscore-mcp) | AI 搜索优化（GEO）MCP 服务器。扫描网站的 AI 搜索就绪度，生成 llms.txt、Schema.org 修复、meta 标签优化。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 支持 Claude/Cursor/Windsurf。 |
 
 ---


### PR DESCRIPTION
## BuyWhere MCP Server

Adds [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) to the **🔍 搜索** section.

**BuyWhere** 是一个专为新加坡和东南亚市场设计的实时商品搜索与比价 MCP 服务器，覆盖 Lazada、Shopee、FairPrice、Courts 等平台的 260,000+ 商品。

**Features:**
- Real-time product search across 260K+ SEA products
- Price comparison across Lazada, Shopee, FairPrice, Courts and more
- Product availability lookup by merchant
- Works with Claude Desktop, CrewAI, Mastra, and any MCP-compatible agent

**Quick start:**
```bash
npx -y @buywhere/mcp-server
```

Or remote (no install):
```json
{
  "mcpServers": {
    "buywhere": {
      "type": "streamable-http",
      "url": "https://mcp.buywhere.ai/mcp",
      "headers": {"Authorization": "Bearer YOUR_API_KEY"}
    }
  }
}
```

Free API keys: https://buywhere.ai/api-keys