### PR TITLE
Add Prismix — AI status + MCP directory + news hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,6 +947,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 * [web目录](https://glama.ai/mcp/servers)。
 * [MCP.ing](https://mcp.ing) 一个资源丰富的 MCP Server库。
 * [MCP Registry](https://github.com/modelcontextprotocol/registry) 官方 MCP 注册中心，统一发现与发布 MCP Server 的元数据服务。
+* [Prismix](https://prismix.dev/mcp) AI 服务状态 + MCP 目录 + AI 新闻三合一平台。收录 500+ MCP 服务器（含精选和 GitHub 自动发现），支持 Bundles（类 Spotify 歌单的 MCP 合集），并提供 75+ AI 服务实时状态监控和邮件告警。内置 MCP Server：`https://prismix.dev/api/v1/mcp`。
 
 ![mcp.ing](https://youjb.com/images/2025/04/25/mcp-ingb03704c206230a97.png)
 


### PR DESCRIPTION
## Changes

Adds [Prismix](https://prismix.dev/mcp) to the 「更多 MCP Server 资源」section.

**Prismix** is a 3-pillar hub for AI builders:

- **MCP Directory**: 500+ MCP servers (80+ curated + GitHub auto-discovery), with Bundles (Spotify-style server playlists), install commands, and release tracking
- **AI Status**: Real-time monitoring for 75+ AI services (OpenAI, Anthropic, Claude, Groq, etc.) with email/webhook alerts
- **AI News**: 70+ curated sources, personalized feed

**Built-in MCP Server**: `https://prismix.dev/api/v1/mcp` — exposes live AI service status as MCP tools for Claude Desktop / Claude Code.

Free to use, no signup needed to browse.

---

希望这个条目对中文开发者有帮助！欢迎提出修改建议。