### PR TITLE
feat: add Prismix to 更多 MCP Server 资源

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,6 +947,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 * [web目录](https://glama.ai/mcp/servers)。
 * [MCP.ing](https://mcp.ing) 一个资源丰富的 MCP Server库。
 * [MCP Registry](https://github.com/modelcontextprotocol/registry) 官方 MCP 注册中心，统一发现与发布 MCP Server 的元数据服务。
+* [Prismix](https://prismix.dev/mcp) 聚合了 80+ 精选 + 500+ 自动发现的 MCP Server，支持 Bundle（分组管理）、每个 Server 的发布时间线（Atom RSS），以及 AI 服务状态监控 + AI 新闻聚合三合一平台。
 
 ![mcp.ing](https://youjb.com/images/2025/04/25/mcp-ingb03704c206230a97.png)
 


### PR DESCRIPTION
## 添加内容

在「更多 MCP Server 资源」板块新增 [Prismix](https://prismix.dev/mcp)。

**Prismix** 是一个三合一 AI Hub：
- **MCP 目录**：80+ 精选 + 500+ 自动发现的 MCP Server（来源：GitHub topic search）
- **Bundle 功能**：将多个 Server 打包成组，生成可直接用于 Claude Desktop 的合并配置
- **发布时间线**：每个 Server 的 GitHub Release 跟踪，支持 Atom RSS 订阅
- **AI 状态监控**：实时监控 75+ AI 服务（OpenAI、Anthropic 等）可用性
- **AI 新闻聚合**：70+ 来源的 AI 资讯，For-You 个性化推送

免费使用，无需注册即可浏览目录。Live: https://prismix.dev/mcp