### PR TITLE
Add VulnFeed to 安全与分析 (Security & Analysis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,6 +851,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [abluva-research/mcp-trust-plane](https://github.com/abluva-research/mcp-trust-plane) | 面向 MCP 的可组合数据安全平面，采集 / 分析 / 防护分层可插拔，覆盖 50+ 企业数据源，为 AI 访问企业数据提供统一的信任与防护层。 | 社区实现, JavaScript 开发 📇, 数据安全平面, 50+ 企业数据源, Apache 2.0。 |
 | [badchars/darknet-mcp-server](https://github.com/badchars/darknet-mcp-server) | 面向安全研究的暗网与威胁情报聚合 MCP 服务器，66 个工具整合 16 个数据源（HIBP 泄露库、ThreatFox/abuse.ch、勒索软件追踪、Tor .onion 访问、恶意软件分析、区块链取证、漏洞与窃密日志检索），让 AI 在一次调用中完成跨平台情报关联。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 暗网与威胁情报聚合 (66 工具/16 源), MIT。 |
 | [EASYHOME-DOORVERSE/dw-mcp-ai-permission-center](https://github.com/EASYHOME-DOORVERSE/dw-mcp-ai-permission-center) | 基于标准 RBAC 的企业级 MCP AI 工具权限管控中台，为 Cursor、Claude Desktop 及自研 Agent 提供统一接入鉴权、按角色的动态工具列表与多数据源数据访问隔离。内置 JDBC/HTTP 接口代理，可将 SQL 与业务接口一键转为 MCP 工具，JWT + API Key 双通道认证。 | 社区实现, Java 开发 ☕, 本地/云端 🏠☁️, MCP 权限管控 (RBAC), Spring AI + Vue3, Apache 2.0。 |
+| [VulnFeed](https://github.com/novadyne-hq/vulnfeed-mcp) | 无需密钥的依赖漏洞扫描 MCP 服务器：读取锁文件（npm/PyPI/Go/Rust/Ruby/PHP），核对 NVD 与 GitHub Advisories，按 EPSS 漏洞利用概率排序并推荐修复版本。 | 社区实现, Python 开发 🐍, 本地运行 🏠, 依赖漏洞扫描 (NVD + GitHub Advisories + EPSS)。 |
 
 ---
 


### PR DESCRIPTION
新增一个依赖漏洞扫描 MCP 服务器 **VulnFeed**（`uvx` 安装，无需密钥）到「🔒 安全与分析」表格。

它读取锁文件（npm/PyPI/Go/Rust/Ruby/PHP），核对 NVD 与 GitHub Advisories，并按 EPSS 漏洞利用概率对结果排序、推荐修复版本。与本节已有的 `roadwy/cve-search_mcp`、`qianniuspace/mcp-security-audit` 属同类工具。

- Repo: https://github.com/novadyne-hq/vulnfeed-mcp
- PyPI: `vulnfeed-mcp`
- 单行改动，遵循表格现有格式。