### PR TITLE
新增 hushvert/mcp 到 📁 文件系统与存储

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Everything Search (mamertofabian)](https://github.com/mamertofabian/mcp-everything-search) | [更新] 在 Windows/macOS/Linux 上快速搜索文件（使用 Everything/mdfind/locate）。 (更新自Awesome列表描述) | 社区实现, Python 开发 🐍, 本地运行 🏠, 跨平台 🪟🍎🐧 快速文件搜索。                         |
 | [Aimino-Tech/opendocswork-mcp](https://github.com/Aimino-Tech/opendocswork-mcp) | Rust 原生、本地优先的 Office 文档处理 MCP 服务器，支持 Excel、Word、PowerPoint，亚毫秒级响应。 | 社区实现, Rust 开发 🦀, 本地运行 🏠, 开源, Office 文档处理。 |
 | [caezium/Burrow](https://github.com/caezium/Burrow) | macOS 原生磁盘清理 GUI（Mole CLI 前端），支持清理、卸载、优化、磁盘分析与实时状态监控，内置 MCP 服务器供 AI 代理调用。 | 社区实现, Swift 开发 🍎, 本地运行 🏠, 开源, macOS 磁盘清理与分析。 |
+| [hushvert/mcp](https://github.com/hushvert/mcp) | 面向 AI 智能体的文件转换服务：通过 hushvert 托管 API 完成 Office 文档转 PDF、PDF 转 Word、文档互转（Markdown/HTML/EPUB/LaTeX）与音视频转码；浏览器可本地完成的转换会引导使用免费本地引擎而不计费。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 文件/文档格式转换 (convert_file/convert_poll/list_formats/check_usage)。 |
 
 ---
 


### PR DESCRIPTION
新增 [hushvert/mcp](https://github.com/hushvert/mcp) 到 **📁 文件系统与存储** 分类（与该分类下的 markitdown、PSPDFKit、opendocswork 等文件/文档转换服务并列）。

面向 AI 智能体的文件转换 MCP 服务，通过 hushvert 托管 API 完成 Office 文档转 PDF、PDF 转 Word、文档互转（Markdown/HTML/EPUB/LaTeX）与音视频转码。浏览器可本地完成的转换会引导使用免费本地引擎而不计费。

- 工具：convert_file / convert_poll / list_formats / check_usage
- npm：`@hushvert/mcp`；官方 MCP Registry：`com.hushvert/mcp`
- 仓库：https://github.com/hushvert/mcp ；许可证：MIT

已按表格格式追加到分类末尾，一个 PR 只新增一个条目。