### PR TITLE
Add Darkmoon

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,6 +892,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [AgentShield](https://github.com/elliotllliu/agent-shield) | AI Agent 技能、MCP 服务器和插件安全扫描器。30 条检测规则，支持 AST 污点追踪、跨文件数据流分析、杀伤链检测、8 语言提示注入检测（中/日/韩/俄/阿/西/法/德）。零安装 (npx)，100% 离线运行。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, AI Agent 安全扫描。 |
 | [abluva-research/mcp-trust-plane](https://github.com/abluva-research/mcp-trust-plane) | 面向 MCP 的可组合数据安全平面，采集 / 分析 / 防护分层可插拔，覆盖 50+ 企业数据源，为 AI 访问企业数据提供统一的信任与防护层。 | 社区实现, JavaScript 开发 📇, 数据安全平面, 50+ 企业数据源, Apache 2.0。 |
 | [badchars/darknet-mcp-server](https://github.com/badchars/darknet-mcp-server) | 面向安全研究的暗网与威胁情报聚合 MCP 服务器，66 个工具整合 16 个数据源（HIBP 泄露库、ThreatFox/abuse.ch、勒索软件追踪、Tor .onion 访问、恶意软件分析、区块链取证、漏洞与窃密日志检索），让 AI 在一次调用中完成跨平台情报关联。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 暗网与威胁情报聚合 (66 工具/16 源), MIT。 |
+| [Darkmoon](https://github.com/ASCIT31/Dark-Moon) | 开源自主式 AI 渗透测试平台，通过 Markdown 剧本与智能体推理编排 80 多种攻击工具，基于 MCP 控制执行，覆盖 Web、云、Active Directory、Kubernetes、API 与内网，并为每个发现提供证据链。 | 社区实现, 开源 (GPL-3.0) 🔓, 自主式 AI 渗透测试平台, 针对 Claude Opus 优化。 |
 | [EASYHOME-DOORVERSE/dw-mcp-ai-permission-center](https://github.com/EASYHOME-DOORVERSE/dw-mcp-ai-permission-center) | 基于标准 RBAC 的企业级 MCP AI 工具权限管控中台，为 Cursor、Claude Desktop 及自研 Agent 提供统一接入鉴权、按角色的动态工具列表与多数据源数据访问隔离。内置 JDBC/HTTP 接口代理，可将 SQL 与业务接口一键转为 MCP 工具，JWT + API Key 双通道认证。 | 社区实现, Java 开发 ☕, 本地/云端 🏠☁️, MCP 权限管控 (RBAC), Spring AI + Vue3, Apache 2.0。 |
 
 ---


### PR DESCRIPTION
在「安全与分析」表格中新增 Darkmoon，一款 GPL-3.0 开源的自主式 AI 渗透测试平台，通过 MCP 协议控制并编排 80 多种攻击工具的执行。它与本分类中 secops-mcp 等以 MCP 驱动安全测试的项目定位相近。