### PR TITLE
Add mcp-seatbelt and mcp-observatory to security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,6 +893,8 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [abluva-research/mcp-trust-plane](https://github.com/abluva-research/mcp-trust-plane) | 面向 MCP 的可组合数据安全平面，采集 / 分析 / 防护分层可插拔，覆盖 50+ 企业数据源，为 AI 访问企业数据提供统一的信任与防护层。 | 社区实现, JavaScript 开发 📇, 数据安全平面, 50+ 企业数据源, Apache 2.0。 |
 | [badchars/darknet-mcp-server](https://github.com/badchars/darknet-mcp-server) | 面向安全研究的暗网与威胁情报聚合 MCP 服务器，66 个工具整合 16 个数据源（HIBP 泄露库、ThreatFox/abuse.ch、勒索软件追踪、Tor .onion 访问、恶意软件分析、区块链取证、漏洞与窃密日志检索），让 AI 在一次调用中完成跨平台情报关联。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 暗网与威胁情报聚合 (66 工具/16 源), MIT。 |
 | [EASYHOME-DOORVERSE/dw-mcp-ai-permission-center](https://github.com/EASYHOME-DOORVERSE/dw-mcp-ai-permission-center) | 基于标准 RBAC 的企业级 MCP AI 工具权限管控中台，为 Cursor、Claude Desktop 及自研 Agent 提供统一接入鉴权、按角色的动态工具列表与多数据源数据访问隔离。内置 JDBC/HTTP 接口代理，可将 SQL 与业务接口一键转为 MCP 工具，JWT + API Key 双通道认证。 | 社区实现, Java 开发 ☕, 本地/云端 🏠☁️, MCP 权限管控 (RBAC), Spring AI + Vue3, Apache 2.0。 |
+| [mcp-observatory](https://github.com/KryptosAI/mcp-observatory) | MCP 服务器可观测性平台 — 监控和分析 MCP 服务器性能、可用性和使用指标，提供健康检查与告警。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, MCP 可观测性与监控, MIT。 |
+| [mcp-seatbelt](https://github.com/KryptosAI/mcp-seatbelt) | MCP 运行时安全护栏 — 检测 8 个客户端配置，通过策略代理包装高风险服务器，在运行时阻止危险工具调用。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, MCP 运行时安全与策略执行, MIT, `npx @kryptosai/mcp-seatbelt` |
 
 ---
 


### PR DESCRIPTION
## Changes

- **mcp-observatory**: MCP 服务器可观测性平台 — 监控和分析 MCP 服务器性能、可用性和使用指标
- **mcp-seatbelt**: MCP 运行时安全护栏 — 检测 8 个客户端配置，通过策略代理包装高风险服务器，在运行时阻止危险工具调用

Both from [KryptosAI](https://github.com/KryptosAI).