### PR TITLE
添加 RunComfy (官方) MCP 服务器

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,6 +778,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [BibiGPT](https://github.com/JimmyLv/bibigpt-skill) | AI 驱动的视频、音频和播客总结工具，支持 YouTube、Bilibili、TikTok 等平台。提供远程 MCP 服务器 (https://bibigpt.co/api/mcp) 和 Claude Code Skill 两种集成方式。 | 社区实现, 云服务 ☁️, 视频/音频/播客总结。 |
 | [ElevenLabs (官方)](https://github.com/elevenlabs/elevenlabs-mcp) | ElevenLabs 官方 MCP 服务器，提供文本转语音、语音克隆、音频转录、配音等能力。 | 官方实现 (ElevenLabs) 🎖️, Python 开发 🐍, 云服务 ☁️, 语音合成 TTS。 |
 | [MiniMax (官方)](https://github.com/MiniMax-AI/MiniMax-MCP) | MiniMax 官方 MCP 服务器，调用其文本转语音、图像生成与视频生成 API。 | 官方实现 (MiniMax) 🎖️, Python 开发 🐍, 云服务 ☁️, 语音/图像/视频生成。 |
+| [RunComfy (官方)](https://github.com/runcomfy-com/runcomfy-mcp) | RunComfy 官方远程 MCP 服务器，调用其 Serverless API (ComfyUI)：创建/管理 GPU 部署、提交异步推理、获取图像/视频结果。远程端点 https://mcp.runcomfy.com/mcp。 | 官方实现 (RunComfy) 🎖️, Python 开发 🐍, 云服务 ☁️, ComfyUI 图像/视频生成。 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -778,7 +778,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [BibiGPT](https://github.com/JimmyLv/bibigpt-skill) | AI 驱动的视频、音频和播客总结工具，支持 YouTube、Bilibili、TikTok 等平台。提供远程 MCP 服务器 (https://bibigpt.co/api/mcp) 和 Claude Code Skill 两种集成方式。 | 社区实现, 云服务 ☁️, 视频/音频/播客总结。 |
 | [ElevenLabs (官方)](https://github.com/elevenlabs/elevenlabs-mcp) | ElevenLabs 官方 MCP 服务器，提供文本转语音、语音克隆、音频转录、配音等能力。 | 官方实现 (ElevenLabs) 🎖️, Python 开发 🐍, 云服务 ☁️, 语音合成 TTS。 |
 | [MiniMax (官方)](https://github.com/MiniMax-AI/MiniMax-MCP) | MiniMax 官方 MCP 服务器，调用其文本转语音、图像生成与视频生成 API。 | 官方实现 (MiniMax) 🎖️, Python 开发 🐍, 云服务 ☁️, 语音/图像/视频生成。 |
-| [RunComfy (官方)](https://github.com/runcomfy-com/runcomfy-mcp) | RunComfy 官方远程 MCP 服务器，调用其 Serverless API (ComfyUI)：创建/管理 GPU 部署、提交异步推理、获取图像/视频结果。远程端点 https://mcp.runcomfy.com/mcp。 | 官方实现 (RunComfy) 🎖️, Python 开发 🐍, 云服务 ☁️, ComfyUI 图像/视频生成。 |
+| [RunComfy (官方)](https://github.com/runcomfy-com/runcomfy-mcp) | RunComfy 官方远程 MCP 服务器，调用其 Serverless API (ComfyUI)：创建/管理 GPU 部署、提交异步推理、获取图像/视频结果。官网 https://www.runcomfy.com ，远程端点 https://mcp.runcomfy.com/mcp。 | 官方实现 (RunComfy) 🎖️, Python 开发 🐍, 云服务 ☁️, ComfyUI 图像/视频生成。 |
 
 ---
 


### PR DESCRIPTION
添加 **RunComfy (官方)** 到「多媒体与内容创作」分类。

- RunComfy 官方远程 MCP 服务器，封装 RunComfy Serverless API (ComfyUI)：创建/管理 GPU 部署、提交异步推理、获取图像/视频结果。
- 仓库：https://github.com/runcomfy-com/runcomfy-mcp
- 远程端点：`https://mcp.runcomfy.com/mcp`
- 已发布到官方 MCP registry：`io.github.runcomfy-com/runcomfy-mcp`

按现有表格格式新增一行（官方实现 🎖️ · Python 🐍 · 云服务 ☁️）。
