### PR TITLE
feat: add SPARDA security gate to security tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,7 +893,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [abluva-research/mcp-trust-plane](https://github.com/abluva-research/mcp-trust-plane) | 面向 MCP 的可组合数据安全平面，采集 / 分析 / 防护分层可插拔，覆盖 50+ 企业数据源，为 AI 访问企业数据提供统一的信任与防护层。 | 社区实现, JavaScript 开发 📇, 数据安全平面, 50+ 企业数据源, Apache 2.0。 |
 | [badchars/darknet-mcp-server](https://github.com/badchars/darknet-mcp-server) | 面向安全研究的暗网与威胁情报聚合 MCP 服务器，66 个工具整合 16 个数据源（HIBP 泄露库、ThreatFox/abuse.ch、勒索软件追踪、Tor .onion 访问、恶意软件分析、区块链取证、漏洞与窃密日志检索），让 AI 在一次调用中完成跨平台情报关联。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 暗网与威胁情报聚合 (66 工具/16 源), MIT。 |
 | [EASYHOME-DOORVERSE/dw-mcp-ai-permission-center](https://github.com/EASYHOME-DOORVERSE/dw-mcp-ai-permission-center) | 基于标准 RBAC 的企业级 MCP AI 工具权限管控中台，为 Cursor、Claude Desktop 及自研 Agent 提供统一接入鉴权、按角色的动态工具列表与多数据源数据访问隔离。内置 JDBC/HTTP 接口代理，可将 SQL 与业务接口一键转为 MCP 工具，JWT + API Key 双通道认证。 | 社区实现, Java 开发 ☕, 本地/云端 🏠☁️, MCP 权限管控 (RBAC), Spring AI + Vue3, Apache 2.0。 |
-
+| [zyx77550/sparda-skills](https://github.com/zyx77550/sparda-skills) | 专为 AI 编程代理（Claude Code、Cursor 等）设计的代码安全 MCP 服务器。应用 Proof-Carrying Code (PCC) 原则，在执行前对大模型生成的代码进行不变量和时序验证，确保修改的绝对安全性。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, AI 代码修改安全网关。 |
 ---
 
 ### 🌍 地理位置与出行


### PR DESCRIPTION
Added SPARDA to the security and analysis section. SPARDA is a proof-carrying code security gate for AI coding agents.