### PR TITLE
新增 UIZZE 到 💻 开发与代码执行

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [iohub/codexray](https://github.com/iohub/codexray) | 仓库感知的本地 MCP，用混合语义 + 全文检索引擎实时理解代码库，按需为 AI 提供相关代码上下文。兼容 Claude Code 与 Codex。 | 社区实现, Rust 开发 🦀, 本地运行 🏠, 混合语义 + 全文代码检索, MIT。 |
 | [21st.dev Magic](https://github.com/21st-dev/magic-mcp)             | 21st.dev 官方集成，创建受顶级设计工程师启发的精美 UI 组件。                          | 官方实现 (21st.dev) 🎖️, UI 组件创建。                                               |
 | [upstash/context7](https://github.com/upstash/context7) | Upstash 出品，为 LLM 和 AI 编辑器实时注入最新的库文档与代码示例，消除模型对过时 API 的幻觉。Cursor / Claude 等一键接入。 | 官方实现 (Upstash) 🎖️, TypeScript 开发 📇, 云服务 ☁️, 实时文档检索, 56K+ Stars。 |
+| [UIZZE](https://uizze.com) | 为 Codex、Claude Code、Cursor 与 Copilot 检索 80 万+ 真实 Web/iOS 界面参考，并提供设计契约、实现验证、审计与完成闸门，帮助减少模板化 UI。 | 官方实现 (UIZZE) 🎖️, 云服务 ☁️, Streamable HTTP, 需 Agent Token, 已登记至官方 MCP Registry。 |
 | [getsentry/sentry-mcp](https://github.com/getsentry/sentry-mcp) | Sentry 官方集成，让 AI 通过自然语言查询错误、性能问题与发布信息，快速定位线上故障根因。 | 官方实现 (Sentry) 🎖️, TypeScript 开发 📇, 云服务 ☁️, 错误监控与可观测性。 |
 | [getsentry/XcodeBuildMCP](https://github.com/getsentry/XcodeBuildMCP) | 面向 iOS/macOS 开发的 MCP 服务器与 CLI，为 AI 代理提供 Xcode 项目构建、运行、模拟器管理与日志捕获等工具，打通 Apple 平台开发工作流。 | 官方实现 (Sentry) 🎖️, TypeScript 开发 📇, 本地运行 🏠, macOS 🍎, Xcode 构建工具, 5.9K+ Stars。 |
 | [pydantic/mcp-run-python](https://github.com/pydantic/mcp-run-python) | Pydantic 出品，在安全的沙盒环境中运行 Python 代码，适合开发编程代理。                   | 官方实现 (Pydantic) 🎖️, Python 开发 🐍, 本地运行 🏠, 安全代码执行。                   |


### PR DESCRIPTION
## 内容

- 在“开发与代码执行”分类新增 UIZZE 官方远程 MCP 服务。
- 条目说明实际能力：检索 80 万+ 真实 Web/iOS 界面参考，并提供设计契约、实现验证、审计与完成闸门。
- 项目链接使用官方首页 https://uizze.com。

## 收录依据

- 官方清单声明 Streamable HTTP 远程端点，并要求 Agent Token。
- 服务已经登记至官方 MCP Registry。
- 官方仓库采用 MIT 许可证，连接方式与能力文档公开。

## 验证

- 官方 MCP 清单可访问并通过其 JSON Schema 声明版本 1.1.7。
- 远程 MCP 端点响应 POST-only 协议约束。
- README 表格格式及空白检查通过。
