### PR TITLE
Add Tavily Hub MCP server (国内 Tavily 聚合网关)

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [MLT-OSS/FirstData](https://github.com/MLT-OSS/FirstData) | 全球最全面的权威数据源知识库，132+ 经验证数据源（政府、国际组织、学术机构），帮助 AI 减少幻觉。提供结构化元数据、100% URL 验证、中英双语支持。目标：1000+ 数据源。 | 本地/云端 🏠☁️，中国数据源深度覆盖 🇨🇳，AI 事实防线，抗幻觉数据底座。 |
 | [GEOScore](https://github.com/henu-wang/geoscore-mcp) | AI 搜索优化（GEO）MCP 服务器。扫描网站的 AI 搜索就绪度，生成 llms.txt、Schema.org 修复、meta 标签优化。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 支持 Claude/Cursor/Windsurf。 |
 | [Episkey-G/GrokSearch-rs](https://github.com/Episkey-G/GrokSearch-rs) | Rust 编写的 MCP 服务器，提供 Grok 联网搜索与 Tavily 支持的来源检索，为 AI 代理补充实时网络信息。 | 社区实现, Rust 开发 🦀, 云服务 ☁️, Grok 联网搜索 + Tavily 检索。 |
+| [sharyuke/tavily-hub](https://github.com/sharyuke/tavily-hub) | Tavily 国内聚合 + Credit 池 + 自费通道 + 号池负载均衡 (MCP streamableHTTP + SSE 双协议，无需海外信用卡、国内直连、5 分钟接入 Claude/Cursor/Cherry 等 9 个客户端)。 | 社区实现, TypeScript 开发, 云服务, Tavily 代理网关, 邀请越多回充越快。 |
 | [NovadaLabs/Novada-mcp](https://github.com/NovadaLabs/Novada-mcp) | 托管 Streamable-HTTP MCP 服务器，提供 25+ 网页数据工具：搜索、SERP、抓取、提取、地图、爬取、深度研究及 6 种代理类型，覆盖 195 个国家。免安装，每月 1000 次免费调用。`npx novada-mcp` | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 全面网页数据采集平台, MIT。 |
 | [Brave Search (官方)](https://github.com/brave/brave-search-mcp-server) | Brave 官方出品的搜索 MCP 服务器，支持网页、本地、图片、新闻、视频搜索。 | 官方实现 (Brave) 🎖️, TypeScript 开发 📇, 云服务 ☁️, Brave 搜索引擎。 |
 


### PR DESCRIPTION
把 Tavily Hub (https://github.com/sharyuke/tavily-hub) 加到「搜索」分类下。Tavily Hub 是 MCP streamableHTTP + SSE 双协议，作为 Tavily 国内聚合代理，免海外信用卡、国内直连，已与 Claude/Cursor/Cherry 等 9 客户端兼容。