### PR TITLE
新增 Bilibili MCP 到 multimedia 多媒体与内容创作

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [anaisbetts/mcp-youtube](https://github.com/anaisbetts/mcp-youtube)              | 获取 YouTube 字幕 (另一版本)。                                                                    | 社区实现, TypeScript 开发 📇, 云服务 ☁️, YouTube 字幕。                                                  |
 | [IDEA-Research/DINO-X-MCP](https://github.com/IDEA-Research/DINO-X-MCP)              |  让 AI 具备细粒度的图像理解能力：识别、定位、描述你看到的任何目标。                                                                     | 官方实现（IDEA-Research）, TypeScript 开发 📇, 本地运行 🏠, 图像识别理解。                                                  |
 | [BibiGPT](https://github.com/JimmyLv/bibigpt-skill) | AI 驱动的视频、音频和播客总结工具，支持 YouTube、Bilibili、TikTok 等平台。提供远程 MCP 服务器 (https://bibigpt.co/api/mcp) 和 Claude Code Skill 两种集成方式。 | 社区实现, 云服务 ☁️, 视频/音频/播客总结。 |
+| [Bilibili MCP](https://github.com/XZXZZX-Ai/bilibili-mcp) | 面向中文用户的 Bilibili MCP 服务器，可提取视频元数据、字幕与结构化转录、章节和热门评论，并在无字幕时支持本地 ASR 回退。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, npm: `@xzxzzx/bilibili-mcp`。 |
 | [ElevenLabs (官方)](https://github.com/elevenlabs/elevenlabs-mcp) | ElevenLabs 官方 MCP 服务器，提供文本转语音、语音克隆、音频转录、配音等能力。 | 官方实现 (ElevenLabs) 🎖️, Python 开发 🐍, 云服务 ☁️, 语音合成 TTS。 |
 | [MiniMax (官方)](https://github.com/MiniMax-AI/MiniMax-MCP) | MiniMax 官方 MCP 服务器，调用其文本转语音、图像生成与视频生成 API。 | 官方实现 (MiniMax) 🎖️, Python 开发 🐍, 云服务 ☁️, 语音/图像/视频生成。 |
 


### PR DESCRIPTION
## 变更

- 在 `multimedia 多媒体与内容创作` 分类新增 Bilibili MCP 条目。
- 使用版本无关的简介，说明视频元数据、字幕与结构化转录、章节、热门评论和本地 ASR 回退能力。

## 原因

该项目面向中文用户，可通过 npm 安装并在本地运行，提供中英文文档，适合收录到中文 MCP 资源列表。

## 验证

- `git diff --check`
- 确认列表中仅出现一次 `XZXZZX-Ai/bilibili-mcp`
- 保留现有 Bilibili 相关条目，未作覆盖或删除