### PR TITLE
新增 AionUi 到 MCP 客户端

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
   - **功能**：对接任意支持 function calling 的 LLM，可视化管理 MCP 服务器。
   - **链接**：[GitHub 仓库](https://github.com/OpenAgentPlatform/Dive)
 
+- **AionUi**
+  - **简介**：开源多 Agent 桌面客户端，把多个终端 AI CLI 装进一个图形界面。
+  - **功能**：支持 MCP 服务器配置与调用；可同时接入 Claude Code、Codex、Gemini CLI、Qwen Code、iFlow 等命令行 Agent（兼容 ACP 协议）；多会话并行对话、本地文件管理，支持自行填入 OpenAI / DeepSeek / Kimi / 智谱 GLM 等模型平台的 API Key。
+  - **链接**：[官网](https://www.aionui.com) | [GitHub 仓库](https://github.com/iOfficeAI/AionUi)
+  - **Tips**：跨平台（Windows、macOS、Linux）；适合想用图形界面管理多个 CLI Agent 与 MCP 服务器的用户。
+
 - **其他MCP客户端资源**  
   - [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients)
 


### PR DESCRIPTION
在「MCP 客户端」分类新增 **AionUi** 一条。

- 项目：https://github.com/iOfficeAI/AionUi （开源，Apache-2.0）
- 定位：开源多 Agent 桌面客户端，支持 MCP 服务器配置与调用，同时可接入 Claude Code / Codex / Gemini CLI / Qwen Code / iFlow 等命令行 Agent（兼容 ACP）。
- 与该分区现有条目（Cherry Studio、5ire、DeepChat 等）同类：图形界面的 MCP 宿主，跨平台桌面应用。
- 已按该分区的「简介 / 功能 / 链接 / Tips」多行块格式书写，描述均为项目真实能力，未使用夸大措辞；未附截图（可按维护者要求补充）。

只改动 README.md 一处，未触碰其他条目。