### PR TITLE
docs: add fencescan (retry-safety scanner for MCP servers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,6 +893,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [abluva-research/mcp-trust-plane](https://github.com/abluva-research/mcp-trust-plane) | 面向 MCP 的可组合数据安全平面，采集 / 分析 / 防护分层可插拔，覆盖 50+ 企业数据源，为 AI 访问企业数据提供统一的信任与防护层。 | 社区实现, JavaScript 开发 📇, 数据安全平面, 50+ 企业数据源, Apache 2.0。 |
 | [badchars/darknet-mcp-server](https://github.com/badchars/darknet-mcp-server) | 面向安全研究的暗网与威胁情报聚合 MCP 服务器，66 个工具整合 16 个数据源（HIBP 泄露库、ThreatFox/abuse.ch、勒索软件追踪、Tor .onion 访问、恶意软件分析、区块链取证、漏洞与窃密日志检索），让 AI 在一次调用中完成跨平台情报关联。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 暗网与威胁情报聚合 (66 工具/16 源), MIT。 |
 | [EASYHOME-DOORVERSE/dw-mcp-ai-permission-center](https://github.com/EASYHOME-DOORVERSE/dw-mcp-ai-permission-center) | 基于标准 RBAC 的企业级 MCP AI 工具权限管控中台，为 Cursor、Claude Desktop 及自研 Agent 提供统一接入鉴权、按角色的动态工具列表与多数据源数据访问隔离。内置 JDBC/HTTP 接口代理，可将 SQL 与业务接口一键转为 MCP 工具，JWT + API Key 双通道认证。 | 社区实现, Java 开发 ☕, 本地/云端 🏠☁️, MCP 权限管控 (RBAC), Spring AI + Vue3, Apache 2.0。 |
+| [aurumflux20/fencescan](https://github.com/aurumflux20/fencescan) | 扫描 MCP 服务器代码，找出重试后可能重复执行的工具调用（如重复扣款、重复发送）。只给出证据和候选项，不给判定——真正的判断需要读代码。零依赖，`npx fencescan` 直接运行。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 零依赖, 重试安全 (retry-safety) 静态扫描, MIT。 |
 
 ---
 


### PR DESCRIPTION
Adds one entry to 🔒 安全与分析 (Security & Analysis).

**fencescan** — scans MCP server code for tool calls that could fire the same effect twice after a retry (duplicate charges, duplicate sends). Zero dependencies, `npx fencescan` with no install. It deliberately reports evidence and candidates rather than verdicts — an outsider reading a repo usually can't prove a double-fire, since the guard often lives in a service the code calls, so the scanner points at what's worth reading rather than asserting a conclusion. MIT licensed.

https://github.com/aurumflux20/fencescan

One entry, matches the existing table format for the section.