### PR TITLE
新增 BitFun 到 MCP 客户端

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
     ![5ire](https://files.mdnice.com/user/43439/0c1c47ad-689d-4302-824e-9dd5e2706e2c.png)
   - **Tips**：适合开发者与非开发者使用，支持多平台（Windows、macOS、Linux）。
 
+- **BitFun**
+  - **简介**：开源跨平台桌面 AI Agent，内置 MCP 客户端。
+  - **功能**：可在桌面端和 CLI 中配置、连接并管理本地或远程 MCP Server，将工具与数据源接入编码、文件系统、终端、浏览器和桌面任务。
+  - **链接**：[GitHub 仓库](https://github.com/GCWing/BitFun)
+  - **Tips**：MIT 开源，支持 Windows、macOS、Linux；仓库含可验证的 Rust MCP 客户端协议和桌面端、CLI 管理实现。
+
 - **Cursor**  
   - **简介**：代码编辑器，装上 MCP 变“全能选手”。  
   - **功能**：写代码、发 Slack、生成图片。  


### PR DESCRIPTION
## 概要

在「MCP 客户端」中新增 [BitFun](https://github.com/GCWing/BitFun)。BitFun 是 MIT 开源的跨平台桌面 AI Agent，可在桌面端和 CLI 中配置、连接、启停及管理本地或远程 MCP Server。

## 可验证的 MCP 实现

- [Rust MCP 客户端握手信息](https://github.com/GCWing/BitFun/blob/main/src/crates/services/services-integrations/src/mcp/protocol/jsonrpc.rs#L27-L36)明确标识 `BitFun MCP Client`
- [CLI MCP 管理实现](https://github.com/GCWing/BitFun/blob/main/src/apps/cli/src/management.rs#L242-L343)提供添加本地 stdio 或远程 Streamable HTTP Server 的三步配置流程
- [桌面端 MCP API](https://github.com/GCWing/BitFun/blob/main/src/apps/desktop/src/api/mcp_api.rs)包含初始化、资源/Prompt 读取、Server 启停、配置保存、远程认证等接口
- 项目已有公开发行版 v0.2.17，支持 Windows、macOS、Linux

## 自查

- 已搜索 README 及公开 PR/Issue，没有发现重复条目
- 链接指向项目官方公开仓库
- 仅新增一个 MCP 客户端条目，使用简洁中文说明
- `git diff --check` 通过

## 利益披露

这是代表 BitFun 项目提交的项目方自荐。
