### PR TITLE
新增 open-mcp-apps 到 🛠️ 效率工具与集成

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [allenporter/mcp-server-home-assistant](https://github.com/allenporter/mcp-server-home-assistant) | 通过 MCP 服务器暴露所有 Home Assistant 语音意图，实现家庭控制。                                  | 社区实现, Python 开发 🐍, 本地运行 🏠, Home Assistant 语音控制。                                    |
 | [yuna0x0/hackmd-mcp](https://github.com/yuna0x0/hackmd-mcp)                | 允许 AI 模型与 HackMD 交互。                                                                   | 社区实现, TypeScript 开发 📇, 云服务 ☁️, HackMD 协作笔记。                                       |
 | [caol64/wenyan-mcp](https://github.com/caol64/wenyan-mcp)                | 文颜 MCP Server， 让 AI 将 Markdown 文章自动排版后发布至微信公众号。                                                                   | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 推荐 Docker 部署。                                       |
+| [open-mcp-apps](https://github.com/2nd1st/open-mcp-apps)                | 开源 MCP Apps 引擎：AI 按需写出可交互的 UI 应用（待办看板、习惯打卡、仪表盘等），保存后可在后续任意对话中按名字直接打开；数据存放在独立的 collections 里，跨会话留存。内置 22 个现成应用的应用商店。 | 社区实现, JavaScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, 33 个工具, 从仓库 install.sh 安装（npm 上的同名包非本项目）。 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [allenporter/mcp-server-home-assistant](https://github.com/allenporter/mcp-server-home-assistant) | 通过 MCP 服务器暴露所有 Home Assistant 语音意图，实现家庭控制。                                  | 社区实现, Python 开发 🐍, 本地运行 🏠, Home Assistant 语音控制。                                    |
 | [yuna0x0/hackmd-mcp](https://github.com/yuna0x0/hackmd-mcp)                | 允许 AI 模型与 HackMD 交互。                                                                   | 社区实现, TypeScript 开发 📇, 云服务 ☁️, HackMD 协作笔记。                                       |
 | [caol64/wenyan-mcp](https://github.com/caol64/wenyan-mcp)                | 文颜 MCP Server， 让 AI 将 Markdown 文章自动排版后发布至微信公众号。                                                                   | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 推荐 Docker 部署。                                       |
-| [open-mcp-apps](https://github.com/2nd1st/open-mcp-apps)                | 开源 MCP Apps 引擎：AI 按需写出可交互的 UI 应用（待办看板、习惯打卡、仪表盘等），保存后可在后续任意对话中按名字直接打开；数据存放在独立的 collections 里，跨会话留存。内置 22 个现成应用的应用商店。 | 社区实现, JavaScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, 33 个工具, 从仓库 install.sh 安装（npm 上的同名包非本项目）。 |
+| [open-mcp-apps](https://github.com/2nd1st/open-mcp-apps)                | 开源 MCP Apps 引擎：AI 按需写出可交互的 UI 应用（待办看板、习惯打卡、仪表盘等），保存后可在后续任意对话中按名字直接打开；数据存放在独立的 collections 里，跨会话留存。内置 22 个现成应用的应用商店。 | 社区实现, JavaScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, 33 个工具, 一行 `npx -y @2nd1st/open-mcp-apps` 安装。 |
 
 ---
 


### PR DESCRIPTION
在「🛠️ 效率工具与集成」分类下新增一行，格式与该表一致。

**项目简介**：开源的 MCP Apps 引擎。AI 按需写出单文件 HTML 的交互式 UI 应用（待办看板、习惯打卡、仪表盘等）并保存进注册表，后续任意对话都能按名字打开；数据存在独立的 collections（SQLite + 追加式变更账本），跨会话、跨宿主留存。可在 Claude Desktop / claude.ai / Codex / ChatGPT 等任意支持 MCP Apps 的宿主里渲染。

- 仓库：https://github.com/2nd1st/open-mcp-apps
- 许可：引擎 AGPL-3.0，`components/` 下的应用 MIT
- 33 个工具，本地 stdio 运行，Node 22+
- 内置 22 个现成应用的应用商店

对照收录标准：开源可验证（引擎与全部应用源码都在仓库内）、有安装脚本、README 说明了工具与接入方式、非付费墙套壳、非聚合目录站。

> 说明：npm 上的 `open-mcp-apps` 是**无关的第三方包**，本项目从仓库的 `install.sh` 安装，条目备注里已注明，避免读者装错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)