### PR TITLE
docs: 修复 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -1151,7 +1151,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=yzfly/Awesome-MCP-ZH&type=Date)](https://www.star-history.com/#yzfly/Awesome-MCP-ZH&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=yzfly/Awesome-MCP-ZH&type=Date)](https://star-history.dera.page/#yzfly/Awesome-MCP-ZH&Date)
 
 ---
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已失效，无法正常加载星标历史数据。本 PR 将图表图片与跳转链接更新为可用的地址，恢复仓库星标历史展示。