### PR TITLE
新增 Covate 到 💻 开发与代码执行

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [ref-tools/ref-tools-mcp](https://github.com/ref-tools/ref-tools-mcp) | 为编程代理提供公共/私有库的文档检索，减少调用陌生 API 时的幻觉并节省上下文窗口。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 文档检索。 |
 | [apollographql/apollo-mcp-server](https://github.com/apollographql/apollo-mcp-server) | Apollo 官方 MCP 服务器，把 GraphQL 操作暴露为 AI 可调用的工具。 | 官方实现 (Apollo GraphQL) 🎖️, Rust 开发 🦀, 本地/云端 🏠☁️, GraphQL 工具化。 |
 | [huggingface/hf-mcp-server](https://github.com/huggingface/hf-mcp-server) | Hugging Face 官方 MCP 服务器，检索 Hub 上的模型、数据集、论文与 Spaces 并调用相关工具。 | 官方实现 (Hugging Face) 🎖️, TypeScript 开发 📇, 云服务 ☁️, HF Hub 集成。 |
+| [SunflowersLwtech/covate](https://github.com/SunflowersLwtech/covate) | AI 编程助手的「学习边车」：对 AI 生成的代码改动自动出题，让开发者在接受前先证明自己看懂了逻辑、安全与性能影响；同时维护一份项目级的调试记忆，供后续会话查询。提供简体、繁体中文 README。 | 社区实现，Python 开发 🐍，本地运行 🏠（stdio / Docker），跨平台 🍎🪟🐧，MIT 许可，面向 AI 编程场景下的技能留存
 
 
 ---


### PR DESCRIPTION
### 新增条目

[SunflowersLwtech/covate](https://github.com/SunflowersLwtech/covate) — 一个开源（MIT）的 MCP 服务器，定位是 AI 编程助手的「学习边车」。

两个能力：

- **对 AI 生成的代码改动出题**：不只记录"写了什么"，而是针对这次改动的逻辑、安全和性能影响生成互动问题，开发者答过才算真的接受。目标是 AI 编程带来的技能退化问题。
- **项目级调试记忆**：持久保存，后续会话中代理可以直接查询。

对照《贡献指南》自查：

- **真实可验证**：MCP 服务器本体在仓库 `src/covate/`，依赖 MCP SDK，定义了工具与服务器入口；已在 Glama 上架（<https://glama.ai/mcp/servers/@SunflowersLwtech/covate>），另有 DeepWiki 文档。
- **可安装 / 可调用**：**目前没有发布 PyPI 包**，安装路径是从源码装（`pyproject.toml` 定义了 `covate` 可执行入口）或 `docker run -i covate`；README 给了客户端 `mcpServers` 接入配置。这一点先讲清楚，如果贵列表要求必须有已发布的包，我会先发 PyPI 再来提交。
- **对中文用户的价值**：仓库提供简体中文与繁体中文 README。
- **格式**：放在「💻 开发与代码执行」分区末尾，沿用该分区的三列表格与全角标点；一个 PR 只加一条，未改动其他行。

利益披露：我是 Covate 的开发者。描述、分区、措辞都可按维护者意见调整。
