### PR TITLE
新增 PostEverywhere 到 📕 社交媒体与内容创作

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,6 +862,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [AiClient](https://github.com/Cooosin/AiClient) | 旅游行程规划 AI 智能体，连接小红书搜索、高德地图和和风天气 MCP 服务。 | 社区实现, Java 开发 ☕, 跨应用集成, 旅游场景 Agent。 |
 | [RednoteMCP](https://github.com/JonaFly/RednoteMCP) | 基于 Playwright 的自动化工具，支持自动登录、搜索特定关键词、获取内容及智能评论。 | 社区实现, Python 开发 🐍, 自动化操作, 笔记检索。 |
 | [Taisly Agent Kit](https://github.com/taisly/agent) | Taisly 官方 MCP 服务器、CLI、SDK 与 Agent Skill，帮助 AI Agent 将短视频发布到 TikTok、Instagram Reels、YouTube Shorts、X、Facebook 等平台。 | 官方实现 (Taisly) 🎖️, TypeScript 开发 📇, 云端/本地 🏠☁️, 远程 MCP: `https://app.taisly.com/mcp`, npm: `@taisly/agent`。 |
+| [PostEverywhere MCP](https://github.com/posteverywhere/mcp) | PostEverywhere 官方 MCP 服务器（33 个工具），让 AI Agent 将帖子定时发布到 Instagram、TikTok、YouTube、LinkedIn、X、Facebook、Threads、Pinterest、Bluesky、Telegram、Discord 共 11 个平台，支持媒体上传、AI 配文与数据分析。 | 官方实现 (PostEverywhere) 🎖️, TypeScript 开发 📇, 云端/本地 🏠☁️, 远程 MCP: `https://mcp.posteverywhere.ai/mcp`, npm: `@posteverywhere/mcp`。 |
 | [XME (XhsMcpElectron)](https://github.com/pmhw/XME) | 小红书 Electron 多账号自动化工具，支持 MCP 协议。 | 社区实现, Go 开发 🐹, 多账号管理, 自动化工具。 |
 | [RedBook-Search-Comment-MCP](https://github.com/chenningling/RedBook-Search-Comment-MCP) | (v1.0版本) 基于 Playwright 的搜索与评论工具，帮助用户完成基础的自动化操作。 | 社区实现, Python 开发 🐍, 旧版本归档 (建议使用 v2.0)。 |
 | [xiaohongshu-mcp-nodejs](https://github.com/ToDieOrNot/xiaohongshu-mcp-nodejs) | 企业级 Node.js 重构版本，支持多账号矩阵管理、反风控、数据采集与发布。 | 社区实现, Node.js 开发 🟢, 矩阵管理, 企业级特性。 |


### PR DESCRIPTION
新增 PostEverywhere 官方 MCP 服务器到社交媒体与内容创作分类。

- 公开仓库: https://github.com/posteverywhere/mcp (TypeScript, MCP SDK)
- npm 安装: `npx -y @posteverywhere/mcp` (最新 1.7.0)
- 远程 MCP (Streamable HTTP + OAuth): https://mcp.posteverywhere.ai/mcp
- 已发布于官方 MCP Registry: ai.posteverywhere/mcp
- 33 个工具: 定时发布、媒体上传、AI 配文/配图、campaign 管理、数据分析、账号健康检查
- 文档: https://developers.posteverywhere.ai/integrations/mcp

与本分类中 Taisly Agent Kit 类似, 是厂商官方实现, 支持 11 个国际社媒平台。格式遵循现有表格行。