### PR TITLE
更新 GoodMemory 安装命令，避免版本过期

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,7 +886,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | :--------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------ |
 | [Agentset](https://github.com/agentset-ai/mcp-server)                            | Agentset 官方集成，连接到 Agentset 的知识库 RAG 系统。                                                          | 官方实现 (Agentset) 🎖️, RAG 知识库集成。                                                             |
 | [Graphlit](https://github.com/graphlit/graphlit-mcp-server)                      | Graphlit 官方集成，将各种来源（Slack, Gmail, 播客等）内容摄入可搜索的 Graphlit 项目。                            | 官方实现 (Graphlit) 🎖️, TypeScript 开发 📇, 云服务 ☁️, 多源内容 RAG。                                |
-| [GoodMemory](https://github.com/hjqcan/GoodMemory)                               | 面向 AI 应用与编码代理的本地优先、可审计记忆层，支持 Codex、Claude Code 和任意 MCP 客户端；提供持久化 SQLite、BM25 召回、审计、纠错、导出、删除与可选受治理写回。 | 官方实现 (GoodMemory) 🎖️, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, MIT, `npm install -g goodmemory@0.7.1`, 官方 MCP Registry。 |
+| [GoodMemory](https://github.com/hjqcan/GoodMemory)                               | 面向 AI 应用与编码代理的本地优先、可审计记忆层，支持 Codex、Claude Code 和任意 MCP 客户端；提供持久化 SQLite、BM25 召回、审计、纠错、导出、删除与可选受治理写回。 | 官方实现 (GoodMemory) 🎖️, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, MIT, `npm install -g goodmemory`, 官方 MCP Registry。 |
 | [Inkeep](https://github.com/inkeep/mcp-server-python)                            | Inkeep 官方集成，基于 Inkeep 的 RAG 搜索你的内容。                                                               | 官方实现 (Inkeep), Python 开发, Inkeep RAG 搜索。                                                     |
 | [Lians](https://github.com/Lians-ai/Lians)                                       | 为任意 AI Agent 提供跨会话持久记忆；支持记忆、语义召回、时间点查询、校正、列出与明确删除，默认使用本地 SQLite。      | 官方实现 (Lians) 🎖️, Python 开发 🐍, 本地运行 🏠, `uvx --from lians-sdk[mcp] lians-mcp`, Apache-2.0。 |
 | [Mengram](https://github.com/alibaizhanov/mengram)                                 | 面向 AI Agent 的多租户记忆基础设施。一个 MCP 服务器提供三种记忆（语义事实、情景事件、可演化的程序性记忆），共 30 个工具。多语言（23 种语言，含中文），按 user_id 隔离。 | 社区实现, Python 开发 🐍, 云服务 ☁️, 多租户 + 三种记忆类型 + 多语言。 |
@@ -1262,4 +1262,3 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 Copyright (c) 2025 云中江树
 
 ---
-


### PR DESCRIPTION
## 变更

将 GoodMemory 条目中的安装命令从固定的 `goodmemory@0.7.1` 改为 `goodmemory`，使读者默认安装 npm `latest`，避免列表在每次稳定发布后立即过期。

## 核验

- 当前 npm `latest`：`goodmemory@0.7.5`
- GitHub 仓库链接与条目描述保持不变
- `git diff --check` 通过