### PR TITLE
Add Pocket Drives MCP to 地理位置与出行

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,6 +1001,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Joooook/12306-mcp](https://github.com/Joooook/12306-mcp) | 基于 MCP 的 12306 火车票查询服务器，支持车次、余票、经停站等信息查询。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 中国铁路 12306 购票信息。 |
 | [滴滴出行 MCP](https://mcp.didichuxing.com/) | 滴滴官方远程 MCP：打车场景的价格预估、下单、行程状态查询与取消，并提供地图能力。 | 官方实现 (滴滴) 🎖️, 远程端点 ☁️ `https://mcp.didichuxing.com/mcp-servers?key=<KEY>`, 另有 sandbox 环境可先联调。 |
 | [double2dev/boltpatternhq-mcp](https://github.com/double2dev/boltpatternhq-mcp) | 为 AI 编程助手提供实时的汽车轮毂改装、PCD 孔距、偏距和螺栓尺寸硬件数据查询（覆盖全球超 1.1 万款车型）。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 汽车工业与车辆数据。 |
+| [RevList/pocket-drives-mcp](https://github.com/RevList/pocket-drives-mcp) | Pocket Drives 公开远程 MCP：搜索、报价、浏览独立主机的豪华/跑车/EV 租赁。支持地点自动补全、可用性、机场/场馆送达、主机展厅。不支持预订——预订在 iOS App 完成。PocketList Inc 只做平台；车源是独立运营商。远程端点：https://pocketdrives.ai/mcp | 社区实现, 远程 Streamable HTTP ☁️, 无鉴权, 官方注册表 `ai.pocketdrives/pocket-drives`。 |
 
 ---
 


### PR DESCRIPTION
Adds Pocket Drives to 地理位置与出行, at the end of the table.

- Listing repo: https://github.com/RevList/pocket-drives-mcp
- Remote Streamable HTTP (no auth): https://pocketdrives.ai/mcp
- Official registry: `ai.pocketdrives/pocket-drives`

Pocket Drives is a P2P luxury/exotic/EV rental marketplace. Independent hosts; PocketList Inc builds the platform. This server searches, quotes, and browses. Booking finishes in the iOS app.

Single new table row only.