### PR TITLE
新增 Secret MCP 到 🔍 搜索

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,8 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [takashiishida/arxiv-latex-mcp](https://github.com/takashiishida/arxiv-latex-mcp) | 获取 arXiv 论文的 LaTeX 源码，以处理数学内容和公式。                                   | 社区实现, Python 开发 🐍, 云服务 ☁️, arXiv LaTeX 源码获取。                                |
 | [the0807/GeekNews-MCP-Server](https://github.com/the0807/GeekNews-MCP-Server) | 检索和处理来自 GeekNews 网站新闻数据的 MCP 服务器。                                      | 社区实现, Python 开发 🐍, 云服务 ☁️, GeekNews 新闻获取。                                  |
 | [Tomatio13/mcp-server-tavily](https://github.com/Tomatio13/mcp-server-tavily) | Tavily AI 搜索 API (社区实现版本)。                                                    | 社区实现, Python 开发 🐍, 云服务 ☁️, Tavily 搜索 (社区 Py 版)。                            |
+
+| [Secret MCP](https://github.com/yyeongjin/secret_mcp) | 面向网页设计分析的 MCP 服务器：搜索 GDWEB 最新案例，为每个结果分别发起独立的 sampling/createMessage 请求，并生成一份可实施的 DESIGN_INDEX 规范。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, npx -y secret-design-mcp。 |
 | [zhsama/duckduckgo-mcp-server](https://github.com/zhsama/duckduckgo-mpc-server) | 提供 DuckDuckGo 搜索功能的基于 TypeScript 的 MCP 服务器。                               | 社区实现, TypeScript 开发 📇, 本地/云端 🏠☁️, DuckDuckGo 搜索 (TypeScript)。             |
 | [Zoom Search](https://github.com/goofrey/zoom-search) | 面向 AI Agent 的搜索与证据 MCP 服务器，通过查询改写、多来源搜索和高价值域名聚焦，返回带来源、告警和运行指标的回答。 | 社区实现, Python 开发 🐍, 本地运行 🏠, `pip install "zoom-search[mcp]"`, 多搜索提供商。 |
 | [mcp-local-rag](https://github.com/nkapila6/mcp-local-rag)           | 本地运行的 RAG 式网页搜索，使用 MediaPipe Embedder 和 DuckDuckGo。                               | 社区实现, Python 开发, 本地 RAG 搜索 (无需 API Key)。                                        |

--- a/README.md
+++ b/README.md
@@ -562,7 +562,6 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [takashiishida/arxiv-latex-mcp](https://github.com/takashiishida/arxiv-latex-mcp) | 获取 arXiv 论文的 LaTeX 源码，以处理数学内容和公式。                                   | 社区实现, Python 开发 🐍, 云服务 ☁️, arXiv LaTeX 源码获取。                                |
 | [the0807/GeekNews-MCP-Server](https://github.com/the0807/GeekNews-MCP-Server) | 检索和处理来自 GeekNews 网站新闻数据的 MCP 服务器。                                      | 社区实现, Python 开发 🐍, 云服务 ☁️, GeekNews 新闻获取。                                  |
 | [Tomatio13/mcp-server-tavily](https://github.com/Tomatio13/mcp-server-tavily) | Tavily AI 搜索 API (社区实现版本)。                                                    | 社区实现, Python 开发 🐍, 云服务 ☁️, Tavily 搜索 (社区 Py 版)。                            |
-
 | [Secret MCP](https://github.com/yyeongjin/secret_mcp) | 面向网页设计分析的 MCP 服务器：搜索 GDWEB 最新案例，为每个结果分别发起独立的 sampling/createMessage 请求，并生成一份可实施的 DESIGN_INDEX 规范。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, npx -y secret-design-mcp。 |
 | [zhsama/duckduckgo-mcp-server](https://github.com/zhsama/duckduckgo-mpc-server) | 提供 DuckDuckGo 搜索功能的基于 TypeScript 的 MCP 服务器。                               | 社区实现, TypeScript 开发 📇, 本地/云端 🏠☁️, DuckDuckGo 搜索 (TypeScript)。             |
 | [Zoom Search](https://github.com/goofrey/zoom-search) | 面向 AI Agent 的搜索与证据 MCP 服务器，通过查询改写、多来源搜索和高价值域名聚焦，返回带来源、告警和运行指标的回答。 | 社区实现, Python 开发 🐍, 本地运行 🏠, `pip install "zoom-search[mcp]"`, 多搜索提供商。 |


### PR DESCRIPTION
新增 Secret MCP：一个可通过 npm 安装的 TypeScript MCP 服务器。它搜索 GDWEB 网页设计案例，对每个结果分别发起独立的 sampling/createMessage 请求，并生成一份可实施的 DESIGN_INDEX 规范。

安装：npx -y secret-design-mcp