### PR TITLE
新增 Magic Hour MCP 到 多媒体与内容创作

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,6 +845,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [RunComfy (官方)](https://github.com/runcomfy-com/runcomfy-mcp) | RunComfy 官方远程 MCP 服务器，调用其 Serverless API (ComfyUI)：创建/管理 GPU 部署、提交异步推理、获取图像/视频结果。官网 https://www.runcomfy.com ，远程端点 https://mcp.runcomfy.com/mcp。 | 官方实现 (RunComfy) 🎖️, Python 开发 🐍, 云服务 ☁️, ComfyUI 图像/视频生成。 |
 | [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio) | 通过 MCP 让编码 Agent 按可编辑时间线编排、编辑、生成并自动组装视频。 | 官方实现 🎖️, TypeScript 开发 📇, 本地运行 🏠, MCP 服务器/命令行/技能集。 |
 | [freeaudiototext-mcp](https://github.com/double2dev/freeaudiototext-mcp) | FreeAudioToText 官方出品的音视频转录 MCP 服务器。让 AI 直接读取音视频文件或 YouTube/TikTok 链接，一键生成带有精准“说话人分离”的高质量文字。纯免费、无时间限制。 | 官方实现 🎖️, TypeScript 开发 📇, 本地/边缘混合 🏠☁️, 音视频转录。 |
+| [Magic Hour (官方)](https://magichour.ai/mcp) | Magic Hour 官方托管的远程 MCP 服务器，通过一个 API Key 调用 Sora 2、Veo 3.1、Kling 3.0、Seedance、MiniMax、WAN 2.2 等视频模型和 GPT-image、Nano Banana Pro、Seedream、Flux 等图像模型，支持换脸、口型同步、会说话的照片与语音生成，提供上传与任务状态查询工具。文档 https://magichour.ai/mcp ，远程端点 https://mcp.magichour.ai/ 。 | 官方实现 (Magic Hour) 🎖️, 云服务 ☁️, 远程端点 `https://mcp.magichour.ai/` (Streamable HTTP), 支持 OAuth 与 API Key, 注册赠送 400 credits + 每日 100 credits, 自托管版 https://github.com/magichourhq/magic-hour-mcp 。 |
 
 ---
 


### PR DESCRIPTION
在「multimedia 多媒体与内容创作」分类新增 Magic Hour 官方托管的远程 MCP 服务器。

- Magic Hour 是 AI 视频/图像生成 API，一个 API Key 可调用 Sora 2、Veo 3.1、Kling 3.0、Seedance、MiniMax、WAN 2.2 等视频模型及 GPT-image、Nano Banana Pro、Seedream、Flux 等图像模型，另有换脸、口型同步、语音生成等能力。
- 远程端点：https://mcp.magichour.ai/ （Streamable HTTP，支持 OAuth 与 API Key）；文档：https://magichour.ai/mcp ；自托管仓库：https://github.com/magichourhq/magic-hour-mcp ；官方 GitHub：https://github.com/magichourhq
- 免费额度：注册赠送 400 credits，每日再送 100 credits，无需绑卡（https://magichour.ai/developer）。

已按 CONTRIBUTING 的三列表格格式与标签规范填写，已确认列表中无重复条目。