### PR TITLE
新增 404.directory 到搜索分类

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 
 | 名称                                                                 | 中文介绍                                                                                           | 备注                                                                                        |
 | :------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------ |
+| [404.directory](https://github.com/MM-sheng/404-directory) | 面向 AI Agent 的只读远程 MCP：搜索 OpenAI、Microsoft Learn、AWS、Cloudflare 当前官方文档，验证公网部署，并按透明信任元数据发现和比较工具。 | 官方实现 🎖️, TypeScript 开发 📇, 云服务 ☁️, Streamable HTTP, 12 个工具, 无需账号/API Key；安装：`npx -y @mmvv1638/404-directory-mcp --source awesome-mcp-zh`。 |
 | [Alibaba Cloud OpenSearch](https://github.com/aliyun/alibabacloud-opensearch-mcp-server) | 阿里云 OpenSearch 官方集成，AI 代理通过标准化接口与 OpenSearch 交互的工具。                      | 官方实现 (Alibaba Cloud) 🎖️, 阿里云搜索服务。                                              |
 | [Exa](https://github.com/exa-labs/exa-mcp-server)                    | Exa 官方集成，使用专为 AI 设计的 Exa 搜索引擎进行搜索。                                             | 官方实现 (Exa) 🎖️, TypeScript 开发 📇, 云服务 ☁️, AI 专用搜索引擎。                         |
 | [Find MCP](https://github.com/agentage/find-mcp)                     | 搜索 17,000+ 个 MCP 服务器 (与官方 MCP Registry 实时同步)，支持云端 Streamable HTTP 与本地 stdio 两种接入方式。 | 官方实现 (agentage) 🎖️, TypeScript 开发 📇, 云端/本地 🏠☁️, MCP 服务器搜索与发现。 |
@@ -1262,4 +1263,3 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 Copyright (c) 2025 云中江树
 
 ---
-


### PR DESCRIPTION
新增一个真实可调用、开源可验证的 MCP Server 条目。

404.directory 不只是导航页：远程 Streamable HTTP 端点当前公开 12 个工具，Agent 可直接执行官方文档搜索、部署验证、网页理解，以及带信任元数据的工具发现；无需账号或 API Key。仓库包含服务端实现、工具 schema、测试和客户端接入文档。

为 stdio 客户端提供公开 npm bridge，条目中的 `--source awesome-mcp-zh` 只记录不可识别个人的渠道标签；每个安装生成随机 Agent ID，服务端只保存不可逆 HMAC，且只有成功工具调用才计入使用指标。

自查：
- 项目仓库和 HTTPS 服务均公开可访问
- 当前生产端点提供 12 个工具
- MIT License
- README 仅新增搜索分类一行，没有新建分类或修改其他条目