### PR TITLE
新增 BuyWhere MCP 到 🔍 搜索

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Episkey-G/GrokSearch-rs](https://github.com/Episkey-G/GrokSearch-rs) | Rust 编写的 MCP 服务器，提供 Grok 联网搜索与 Tavily 支持的来源检索，为 AI 代理补充实时网络信息。 | 社区实现, Rust 开发 🦀, 云服务 ☁️, Grok 联网搜索 + Tavily 检索。 |
 | [NovadaLabs/Novada-mcp](https://github.com/NovadaLabs/Novada-mcp) | 托管 Streamable-HTTP MCP 服务器，提供 25+ 网页数据工具：搜索、SERP、抓取、提取、地图、爬取、深度研究及 6 种代理类型，覆盖 195 个国家。免安装，每月 1000 次免费调用。`npx novada-mcp` | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 全面网页数据采集平台, MIT。 |
 | [Brave Search (官方)](https://github.com/brave/brave-search-mcp-server) | Brave 官方出品的搜索 MCP 服务器，支持网页、本地、图片、新闻、视频搜索。 | 官方实现 (Brave) 🎖️, TypeScript 开发 📇, 云服务 ☁️, Brave 搜索引擎。 |
+| [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) | 跨境电商商品目录 MCP：跨 SG/MY/VN/TH/PH/US/JP 七个国家 3.7 亿+ 商品实时搜索与比价（`deliver_to` 配送信号），覆盖 13 个工具（search_products / find_best_price / get_deals 等）。OAuth 2.1 Bearer 鉴权，免邮箱注册。已上架官方 MCP Registry（`io.github.BuyWhere/buywhere-mcp@1.1.0`）。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 远程端点 `https://mcp.buywhere.ai/mcp`, MIT。 |
 
 ---
 


### PR DESCRIPTION
## 新增
BuyWhere MCP — 跨境电商商品目录 MCP，跨 SG/MY/VN/TH/PH/US/JP 7 国 3.7 亿+ 商品实时搜索与比价。

## 收录依据（对照贡献指南）
- ✅ 真实 MCP Server: https://github.com/BuyWhere/buywhere-mcp — TypeScript 实现，基于官方 MCP SDK，定义 13 个工具 (`search_products / find_best_price / get_deals / get_product / list_categories / get_categories / get_product_offers / get_product_reviews / get_merchant / get_shipping / get_price_history / find_best_deal / suggest_products`)。
- ✅ 可安装/可调用: 远程端点 `https://mcp.buywhere.ai/mcp`（Streamable HTTP），OAuth 2.1 Bearer 鉴权，已上架官方 MCP Registry（`io.github.BuyWhere/buywhere-mcp@1.1.0`，`isLatest: true`）。
- ✅ 文档清晰: README 含中文/英文双语，说明 13 工具、鉴权、安装、客户端接入示例。
- ✅ 对中文用户有价值: 服务覆盖 SG/MY/VN/TH/PH 东南亚市场，对中文出海卖家/比价场景实用。

## 分类
插入到 🔍 搜索 表格末尾（紧随 Brave Search 之后），按 `Brave → BuyWhere` 字典序相邻。

## 备注字段（按贡献指南格式）
- 社区实现（非官方）
- TypeScript 开发 📇
- 云服务 ☁️（远程端点）
- 远程端点 `https://mcp.buywhere.ai/mcp`
- MIT License

## Diff

```diff
 | [Brave Search (官方)](https://github.com/brave/brave-search-mcp-server) | Brave 官方出品的搜索 MCP 服务器，支持网页、本地、图片、新闻、视频搜索。 | 官方实现 (Brave) 🎖️, TypeScript 开发 📇, 云服务 ☁️, Brave 搜索引擎。 |
+| [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) | 跨境电商商品目录 MCP：跨 SG/MY/VN/TH/PH/US/JP 七个国家 3.7 亿+ 商品实时搜索与比价（`deliver_to` 配送信号），覆盖 13 个工具（search_products / find_best_price / get_deals 等）。OAuth 2.1 Bearer 鉴权，免邮箱注册。已上架官方 MCP Registry（`io.github.BuyWhere/buywhere-mcp@1.1.0`）。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 远程端点 `https://mcp.buywhere.ai/mcp`, MIT。 |
```

一个 PR 只做一件事（新增一个条目）。