### PR TITLE
新增 Concord MCP 到开发与代码执行

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Muvon/octocode](https://github.com/Muvon/octocode) | Rust 编写的语义代码索引器，构建代码库 GraphRAG 知识图谱并通过 MCP 暴露给 AI 代理。支持 13+ 语言，提供 tree-sitter 解析、ast-grep 结构化搜索和代码签名视图。 | 社区实现, Rust 开发 🦀, 本地运行 🏠, 跨平台 🍎🪟🐧, 语义搜索 + GraphRAG 知识图谱, Apache 2.0。 |
 | [blackwell-systems/agent-lsp](https://github.com/blackwell-systems/agent-lsp) | 将语言服务器（gopls、rust-analyzer、pyright、jdtls 等）编排为 AI 代理原生工作流，提供 65 个代码智能工具，覆盖 30 种 CI 验证语言：影响范围分析、查找引用/调用者、重命名、推测式编辑（写盘前预览诊断）以及 GCF 令牌优化输出。单个 Go 二进制文件。 | 社区实现, Go 开发 🐹, 本地运行 🏠, 跨平台 🍎🪟🐧, 编排真实语言服务器, GCF 令牌优化, MIT。 |
 | [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) | 多智能体编排器，协调 37 个 CLI 编码代理（Claude Code、Codex、Gemini CLI、Cursor、Aider 等）在并行 Git worktree 中运行。内置 MCP 服务器模式（stdio + HTTP/SSE）。 | 社区实现, Python 开发 🐍, 本地/云端 🏠☁️, Apache 2.0, 确定性调度器, 多代理编排。 |
+| [Concord MCP](https://github.com/Get-Concord-AI/concord-mcp) | 为 Claude Code、Codex、Gemini CLI、OpenCode 等编码代理提供跨 harness 通信与共享工作状态：任务认领、编辑冲突检测、持久进度更新、所有权转移和证据化交接。 | 官方实现 (Concord AI) 🎖️, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, MIT, 官方 MCP Registry 已收录, `npm install -g @concord-ai/concord-mcp`。 |
 | [aresyn/codex-control-plane-mcp](https://github.com/aresyn/codex-control-plane-mcp) | 面向 Codex Desktop 长任务的持久化 MCP 控制平面，统一调度、跟踪与恢复长时运行的智能体任务，让 AI 可靠地驱动长周期编码工作流。 | 社区实现, Python 开发 🐍, 本地运行 🏠, 长任务编排与持久化控制平面, Apache 2.0。 |
 | [DeusData/codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) | 高性能代码智能 MCP 服务器，将整个代码库索引为持久化知识图谱，为 AI 代理提供调用关系、依赖与代码结构记忆，按需精准检索相关上下文。 | 社区实现, 本地运行 🏠, 代码智能 + 持久化知识图谱, 17K+ Stars。 |
 | [win4r/codebase-memory-mcp-pro](https://github.com/win4r/codebase-memory-mcp-pro) | 纯 C 实现的代码知识图谱 MCP 服务器，构建并增量重索引代码库的调用关系图，为 AI 提供代码结构记忆。整合 9 个上游 PR，修复增量重索引的 CALLS 边。 | 社区实现, C 开发, 本地运行 🏠, 代码知识图谱 + 增量重索引, MIT。 |
@@ -1262,4 +1263,3 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 Copyright (c) 2025 云中江树
 
 ---
-


### PR DESCRIPTION
新增 **Concord MCP** 到「开发与代码执行」分类。

Concord 为 Claude Code、Codex、Gemini CLI、OpenCode 等编码代理提供跨 harness 通信和共享工作状态，包括任务认领、编辑冲突检测、持久进度更新、所有权转移和证据化交接。项目由 Concord AI 官方维护，已发布到 npm 和官方 MCP Registry。

- 仓库：https://github.com/Get-Concord-AI/concord-mcp
- npm：`@concord-ai/concord-mcp`
- MCP Registry：`io.github.Get-Concord-AI/concord-mcp`
- 许可证：MIT

已检查：`git diff --check`，仓库与 npm registry 链接均可访问。