### PR TITLE
Add Persona — 本地优先工作区，内置 MCP 服务器 | local-first workspace with MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1146,6 +1146,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 ![mcp.ing](https://youjb.com/images/2025/04/25/mcp-ingb03704c206230a97.png)
 
 
+- [Persona](https://github.com/jayamitkatariya/personacli) - Local-first personal workspace: notes, tasks, and AI chat over plain Markdown files. Connects to Ollama for free private AI.
 ## MCP 更多玩法
 
 * [mcp-agent](https://github.com/lastmile-ai/mcp-agent): Build effective agents using Model Context Protocol and simple workflow patterns


### PR DESCRIPTION
Add [Persona](https://github.com/jayamitkatariya/personacli) — local-first personal workspace (English/中文 friendly README). Built-in MCP server exposes 15 tools over plain-Markdown notes and tasks so agents can read/write a persistent knowledge base. Ollama AI included. MIT.