### PR TITLE
新增 InstaSeer 到 💬 通讯与协作

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Google Tasks (by zcaceres)](https://github.com/zcaceres/gtasks-mcp)   | Google Tasks API 服务器。                                                                   | 社区实现, TypeScript 开发 📇, 云服务 ☁️, Google Tasks 管理 (TS)。                        |
 | [Nylas CLI](https://github.com/nylas/cli) | 邮件、日历和联系人 MCP 服务器。一次身份验证即可覆盖 Gmail、Outlook、Exchange、Yahoo、iCloud 和 IMAP 共六大邮件服务商的 16 个工具。`nylas mcp install` 一键安装。 | 官方实现 (Nylas) 🎖️, Go 开发 🏎️, 云服务 ☁️, 跨平台 🍎🪟🐧, 邮件/日历/联系人统一接入。文档：https://cli.nylas.com |
 | [TwitterAPI.io MCP Server](https://github.com/kaitoInfra/twitterapi-io-mcp-server) | 对接 twitterapi.io（Twitter/X 数据 API）的官方 MCP 服务器。12 个只读工具：推文搜索（支持完整搜索操作符）、用户档案、关注者、对话线程、趋势话题、互动指标。npm `@twitterapi_io/mcp-server`。 | 官方实现 🎖️, TypeScript 开发 📇, 云服务 ☁️, X/Twitter 数据 API 集成。 |
+| [InstaSeer](https://www.instaseer.com/mcp) | Instagram / TikTok / Facebook 公开账号受众分析 MCP 服务器：拉取任意公开主页的完整历史帖文、互动数据（点赞/评论/互动率）与发帖时间热力图，供 AI Agent 做竞品与内容分析。提供免费额度。 | 官方实现 (InstaSeer) 🎖️, 云服务 ☁️, 远程 Streamable HTTP `https://www.instaseer.com/mcp`（无状态，OAuth 2.1 或 API Key），5 个工具，免费套餐 50 credits/月，已收录官方 MCP Registry (`com.instaseer/mcp`)。文档：https://www.instaseer.com/instagram-analysis-in-claude-chatgpt |
 
 ---
 


### PR DESCRIPTION
新增一个 Instagram / TikTok / Facebook 公开数据分析的远程 MCP 服务器。

- 远程端点：https://www.instaseer.com/mcp （Streamable HTTP，无状态，OAuth 2.1 + API Key 两种鉴权）
- 5 个工具，覆盖公开主页的历史帖文抓取、互动指标与发帖时间热力图
- 免费套餐 50 credits/月，无需付费即可验证
- 已在官方 MCP Registry 发布：`com.instaseer/mcp`（registry.modelcontextprotocol.io）
- 接入文档：https://www.instaseer.com/instagram-analysis-in-claude-chatgpt
- 公开文档仓库：https://github.com/singaporeandurian/instaseer-mcp

已阅读 CONTRIBUTING.md，本 PR 只新增一行，格式与该分类现有条目保持一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)