### PR TITLE
新增「桌面与 GUI 自动化」分类并收录 ClawTouch MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
   - [🌐 浏览器自动化与网页交互](#浏览器自动化与网页交互)
   - [💻 开发与代码执行](#开发与代码执行)
   - [🖥️ 命令行与 Shell 交互](#命令行与-shell-交互)
+  - [🖱️ 桌面与 GUI 自动化](#桌面与-gui-自动化)
   - [🔄 版本控制 (Git / GitHub / GitLab)](#版本控制-git--github--gitlab)
   - [🗄️ 数据库交互](#数据库交互)
   - [☁️ 云平台与服务集成 (AWS, Cloudflare, Azure, K8s, etc.)](#云平台与服务集成-aws-cloudflare-azure-k8s-etc)
@@ -394,6 +395,16 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) | 多功能工具，可管理/执行程序，读/写/搜索/编辑代码和文本文件。(也含代码/文件功能)             | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, 命令行/文件/程序管理。          |
 | [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) | 自修复 CLI 目录，将网页、桌面应用、Electron 应用、外部 CLI 作为确定性命令通过一个 MCP 服务器暴露给 AI 代理；声明式 YAML 适配器加结构化错误信封，调用失败时代理可直接编辑 YAML 并重试。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, Apache-2.0；目录规模与每次调用 token 预算见仓库 [README](https://github.com/olo-dot-io/Uni-CLI#readme) 与 [`docs/BENCHMARK.md`](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/BENCHMARK.md)。 |
 | [5dive MCP](https://github.com/5dive-ai/5dive-mcp) | 5dive 官方 MCP 服务器，把 5dive 智能体舰队 CLI（任务、智能体、摘要）暴露为 MCP 工具，让 MCP 客户端直接调度运行在你自己服务器上的多个自治编码智能体。 | 官方实现 🎖️, JavaScript 开发 📇, 本地运行 🏠, MIT 开源, 已收录于 MCP 官方注册表, 安装：`npx -y @5dive/mcp`。 |
+
+---
+
+### 🖱️ 桌面与 GUI 自动化
+
+*(让 AI 操作桌面图形界面：鼠标、键盘、窗口)*
+
+| 名称                                                          | 中文介绍                                                                                                                                                              | 备注                                                                                                          |
+| :------------------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------ |
+| [ClawTouch MCP](https://github.com/tinqiao-oss/clawtouch-mcp) | 通过外接 USB HID 硬件（树莓派 Pico 2，固件开源）驱动真实鼠标键盘：移动、点击、拖拽、输入、组合键、滚动；另有窗口枚举与按窗口裁剪的截图。被控机不需要安装任何软件；`--mock` 模式可无硬件试用。 | 社区实现, Python 开发 🐍, 本地运行 🏠, 需外接 HID 硬件, 跨平台 🪟🍎🐧（窗口相关功能以 Windows 最完整）。 |
 
 ---
 


### PR DESCRIPTION
收录 **ClawTouch MCP**，并为它新增一个分类「🖱️ 桌面与 GUI 自动化」。

## 关于新增分类

CONTRIBUTING 说新分类要先确认现有分类装不下，我逐个对照过：

- **🌐 浏览器自动化与网页交互** — 那是浏览器内部，这个是操作系统桌面
- **🖥️ 命令行与 Shell 交互** — 那一段的定义是「执行命令行指令、与 Shell 交互」，而这个项目不执行任何命令，是发 USB HID 报文驱动鼠标键盘
- **🛠️ 效率工具与集成** — 那一段是 SaaS 集成（Paragon / Make / Taskade / 腾讯文档）

GUI 自动化在 MCP 生态里已经是独立一类（`punkpeye/awesome-mcp-servers` 有专门的 OS Automation 分类），所以这里补一个。顶部目录已同步更新，新分类放在「命令行与 Shell 交互」之后。

**如果维护者不想加分类**，我可以改放到「命令行与 Shell 交互」段末尾，说一声我就改。

## 关于这个项目

用外接 USB HID 硬件（树莓派 Pico 2，固件同样开源）驱动真实鼠标键盘，而不是用系统 API 合成事件。所以被控的那台机器上不需要装任何东西。除了 移动 / 点击 / 拖拽 / 输入 / 组合键 / 滚动，还有窗口枚举和按窗口裁剪的截图（给视觉模型用）。

- MIT，PyPI 上是 [`clawtouch-mcp`](https://pypi.org/project/clawtouch-mcp/)，已收录于 MCP 官方注册表
- 有完整中文 README
- 备注列里写明了「需外接 HID 硬件」和「窗口相关功能以 Windows 最完整」—— 这两点是真实限制，没有隐去
