### PR TITLE
新增 Magic Hour MCP 到多媒体与内容创作

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,6 +895,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Bilibili MCP](https://github.com/XZXZZX-Ai/bilibili-mcp) | 面向中文用户的 Bilibili MCP 服务器，可提取视频元数据、字幕与结构化转录、章节和热门评论，并在无字幕时支持本地 ASR 回退。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, npm: `@xzxzzx/bilibili-mcp`。 |
 | [ElevenLabs (官方)](https://github.com/elevenlabs/elevenlabs-mcp) | ElevenLabs 官方 MCP 服务器，提供文本转语音、语音克隆、音频转录、配音等能力。 | 官方实现 (ElevenLabs) 🎖️, Python 开发 🐍, 云服务 ☁️, 语音合成 TTS。 |
 | [MiniMax (官方)](https://github.com/MiniMax-AI/MiniMax-MCP) | MiniMax 官方 MCP 服务器，调用其文本转语音、图像生成与视频生成 API。 | 官方实现 (MiniMax) 🎖️, Python 开发 🐍, 云服务 ☁️, 语音/图像/视频生成。 |
+| [Magic Hour MCP](https://github.com/magichourhq/magic-hour-mcp) | 由 [Magic Hour](https://magichour.ai) 官方维护的远程 MCP 服务器，让 AI 助手生成和编辑视频、图像与音频。 | 官方实现 (Magic Hour) 🎖️, Python 开发 🐍, 云服务 ☁️, Streamable HTTP `https://mcp.magichour.ai/`, API Key/OAuth 认证。 |
 | [RunComfy (官方)](https://github.com/runcomfy-com/runcomfy-mcp) | RunComfy 官方远程 MCP 服务器，调用其 Serverless API (ComfyUI)：创建/管理 GPU 部署、提交异步推理、获取图像/视频结果。官网 https://www.runcomfy.com ，远程端点 https://mcp.runcomfy.com/mcp。 | 官方实现 (RunComfy) 🎖️, Python 开发 🐍, 云服务 ☁️, ComfyUI 图像/视频生成。 |
 | [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio) | 通过 MCP 让编码 Agent 按可编辑时间线编排、编辑、生成并自动组装视频。 | 官方实现 🎖️, TypeScript 开发 📇, 本地运行 🏠, MCP 服务器/命令行/技能集。 |
 | [freeaudiototext-mcp](https://github.com/double2dev/freeaudiototext-mcp) | FreeAudioToText 官方出品的音视频转录 MCP 服务器。让 AI 直接读取音视频文件或 YouTube/TikTok 链接，一键生成带有精准“说话人分离”的高质量文字。纯免费、无时间限制。 | 官方实现 🎖️, TypeScript 开发 📇, 本地/边缘混合 🏠☁️, 音视频转录。 |


### PR DESCRIPTION
## 说明

- 在“多媒体与内容创作”分类加入 Magic Hour 官方 MCP 服务器
- 提供公开源码、远程 Streamable HTTP 端点和中文能力说明
- 标明 API Key/OAuth 认证方式

源码与接入文档：https://github.com/magichourhq/magic-hour-mcp
