### PR TITLE
新增 pangolinfo-mcp 到 🛒 电商商家经营

### DIFF
--- a/README.md
+++ b/README.md
@@ -929,6 +929,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | 名称 | 中文介绍 | 备注 |
 | :--- | :--- | :--- |
 | [mcp-cn-commerce](https://github.com/TonyWang-hub/mcp-cn-commerce) | 中国电商商家经营数据 MCP 套件，覆盖抖店/京东/淘宝/拼多多/快手/小红书/微信小店/巨量引擎 8 平台，147 个工具（订单、商品、售后、库存、广告报表），全部只读、本地运行。 | 社区实现, Python 开发 🐍, `pip install mcp-cn-commerce`, 商家经营数据（非内容发布）。 |
+| [pangolinfo-mcp](https://github.com/Pangolin-spg/pangolinfo-mcp) | 亚马逊数据 MCP 服务，提供 19 个只读工具：商品详情、评论、关键词搜索、类目与蓝海细分分析、Best Sellers、New Releases、卖家店铺在售商品，以及 AI Overview / AI Mode 搜索结果与关键词趋势；另含 WIPO 商标检索与美国 PACER 专利诉讼查询，可在上架前排查 IP 风险。通过远程 Streamable HTTP 端点接入，无需自建爬虫与代理池。 | 官方实现 (PANGOLIN INFO TECH) 🎖️, Python 开发 🐍, `pip install pangolinfo-mcp`, 云端运行 ☁️, 已收录于官方 MCP Registry, 覆盖 20+ 亚马逊站点。 |
 
 ---
 


### PR DESCRIPTION
按贡献指南，在「🛒 电商商家经营 (E-Commerce)」分类下新增一行，置于现有 mcp-cn-commerce 条目之后。

**自查对照收录标准：**

- **真实可验证**：仓库 https://github.com/Pangolin-spg/pangolinfo-mcp 有公开的 Python 客户端源码；远程端点 `https://mcp.pangolinfo.com/mcp` 稳定可访问（Streamable HTTP），可实际调用 tools/list 拿到 19 个工具定义。
- **可安装 / 可调用**：提供 PyPI 包（`pip install pangolinfo-mcp`）与 npm 包 `pangolinfo-amazon-data-mcp`（stdio 桥接），同时支持远程端点直连。
- **已收录于官方 MCP Registry**：命名空间 `io.github.Pangolin-spg/pangolinfo-mcp`。
- **文档清晰**：https://docs.pangolinfo.com

说明一点以免评审误会：服务端本身是托管服务（类似列表里已有的 Browserbase 等云端实现），仓库内是客户端源码与配置说明，远程工具 schema 由服务端在启动时下发。若评审认为这不符合「仓库内可验证实现」的标准，我理解并接受关闭。

一个 PR 只做一件事：新增单个条目。描述已按「中文介绍 + 备注」两栏的既有格式填写，未使用推广性措辞。
