### PR TITLE
新增 OrcaReplay 到 💻 开发与代码执行

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 
 | 名称                                                                 | 中文介绍                                                                              | 备注                                                                                 |
 | :------------------------------------------------------------------- | :------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------------- |
+| [Continuum-AI-Corp/OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) | 让编码 Agent 读取并重跑自己的历史运行：先录下一次完整运行（模型请求、Shell 退出码与耗时、每轮文件改动、MCP 调用），之后可离线逐字节重放，或从任意检查点分叉换一个模型重跑。六个 stdio 工具：列出运行、查看时间线、检查点、因果图（每条边标注是「记录到的」还是「推断的」）、重放（离线、不耗 token）、跨模型对比。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, Apache-2.0, `npx -y orcareplay mcp`。 |
 | [FastCtx](https://github.com/yc-duan/fastctx) | Rust 本地工具运行时：为 Agent 提供省上下文的文件读取、内容搜索、文件发现、批量替换与 Bash 执行，中英双语文档。 | 社区实现, Rust 开发 🦀, 本地运行 🏠, Apache-2.0。 |
 | [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) | 模型中立的编码运行时，通过 MCP 给任意 AI 聊天或 Agent 一双「安全的手」操作代码库。 | 社区实现, 本地运行 🏠, Apache-2.0, 中英文档。 |
 | [Godot-MCP](https://github.com/IvanMurzak/Godot-MCP) | Godot 编辑器 C# 插件：让 Claude / Cursor / Copilot 等在 Godot 内创建节点、编辑场景、驱动项目，Unity-MCP 的 Godot 版。 | 社区实现, C# 开发, 本地运行 🏠, Apache-2.0。 |


### PR DESCRIPTION
在 `### 💻 开发与代码执行` 分类下新增一行，其余未改动。一个 PR 只做这一件事。

## 是什么

[OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) 让编码 Agent 读取并重跑自己的历史运行。

先用 `orca record claude`（或 codex / opencode）录下一次完整运行——模型请求、Shell 退出码与耗时、每轮文件改动、MCP 调用，全都落在同一条时间线上。之后 `orca mcp` 把这个 trace 存储通过 stdio 交给 Agent：

| 工具 | 作用 |
|---|---|
| `orca_list_runs` | 有哪些运行 |
| `orca_show_run` | 某次运行的时间线 |
| `orca_checkpoints` | 可以从哪些点分叉 |
| `orca_graph` | 什么导致了什么，每条边标注「记录到的」还是「推断的」，并说明依据的规则 |
| `orca_replay` | 离线重放，不联网、不耗 token |
| `orca_compare` | 同一任务跑多个模型；这条在自己的工具描述里写明会花真钱，因为模型选工具时只读这段字符串 |

典型用法是问它「你昨天为什么删了那个迁移文件」，它去查录像而不是靠记忆猜。

## 对照收录标准自查

- **真实可验证的 MCP Server** — 实现在 [`packages/cli/src/mcp-server.ts`](https://github.com/Continuum-AI-Corp/OrcaReplay/blob/main/packages/cli/src/mcp-server.ts)，有对应测试 `packages/cli/test/mcp-server.test.ts`，不是空壳或落地页
- **可安装 / 可调用** — npm 上是 [`orcareplay`](https://www.npmjs.com/package/orcareplay)，`npx -y orcareplay mcp` 直接跑，无需 API key、无需环境变量
- **文档清晰** — README 写明六个工具各自做什么，另有 trace 格式规范、架构文档、插件开发文档
- **License** — Apache-2.0；trace 规范单独用 CC BY 4.0，方便别人用其他语言重写 reader
- **非付费墙套壳** — 全部功能本地跑，重放完全离线；唯一联网的是 `orca_compare`，且它自己声明了
- **非聚合导航站** — 是工具本身，不是目录
- **无重复** — 提交前搜过 README，0 处命中

## 需要说明的一点

项目比较新（2026 年 8 月开源，目前 69 star），按贵仓库「过于新近且无任何使用沉淀」这一条，我理解可能会被判定为暂缓收录。放在这里由维护者判断：能拿出来的验证材料是公开仓库、npm 包、1,393 个测试、trace 格式规范，以及一份用真实 bug 做的端到端验证记录（[docs/validation.md](https://github.com/Continuum-AI-Corp/OrcaReplay/blob/main/docs/validation.md)，录制→离线重放→从检查点分叉，过程中暴露并修掉了四个问题）。如果认为还需要沉淀，我完全理解，过段时间再提。

## 对中文用户的价值

调试国内网关后面的编码 Agent 时，模型是黑盒、harness 也是黑盒，出问题只能靠翻终端回滚。这个工具把那次运行变成一个可以反复重跑的文件，并且支持换模型重跑同一段上下文来做横向对比——`orca setup` 里网关地址是一个可以随便改的普通 URL，指向任何兼容网关都行。README 与 capture 文档都有中文版。

利益相关：我是 OrcaReplay 的开发者。
