### PR TITLE
新增 Speak AI 到 multimedia 多媒体与内容创作

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,6 +898,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [RunComfy (官方)](https://github.com/runcomfy-com/runcomfy-mcp) | RunComfy 官方远程 MCP 服务器，调用其 Serverless API (ComfyUI)：创建/管理 GPU 部署、提交异步推理、获取图像/视频结果。官网 https://www.runcomfy.com ，远程端点 https://mcp.runcomfy.com/mcp。 | 官方实现 (RunComfy) 🎖️, Python 开发 🐍, 云服务 ☁️, ComfyUI 图像/视频生成。 |
 | [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio) | 通过 MCP 让编码 Agent 按可编辑时间线编排、编辑、生成并自动组装视频。 | 官方实现 🎖️, TypeScript 开发 📇, 本地运行 🏠, MCP 服务器/命令行/技能集。 |
 | [freeaudiototext-mcp](https://github.com/double2dev/freeaudiototext-mcp) | FreeAudioToText 官方出品的音视频转录 MCP 服务器。让 AI 直接读取音视频文件或 YouTube/TikTok 链接，一键生成带有精准“说话人分离”的高质量文字。纯免费、无时间限制。 | 官方实现 🎖️, TypeScript 开发 📇, 本地/边缘混合 🏠☁️, 音视频转录。 |
+| [Speak AI](https://github.com/speakai/speakai-mcp) | 语音与视频转录（支持 100+ 种语言）、AI 分析与基于自定义评分标准的通话评分；官方 MCP 服务器，npm 包 @speakai/mcp-server，MIT 协议。 | 官方实现 (Speak AI) 🎖️, TypeScript 开发 📇, 云服务 ☁️, 语音识别 ASR / 通话评分, npm: `@speakai/mcp-server`。 |
 
 ---
 


### PR DESCRIPTION
- 新增 Speak AI 官方 MCP 服务器：语音/视频转录（100+ 语言）、AI 分析、基于自定义评分标准的通话评分。
- 官方维护，仓库 https://github.com/speakai/speakai-mcp ，npm 包 @speakai/mcp-server，MIT 协议。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECfv85U3ZpQrHapVskBN8z