### PR TITLE
更新 RunComfy (官方) 条目：工具数从 10 增至 31，新增托管模型推理与 LoRA 训练

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,7 +895,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Bilibili MCP](https://github.com/XZXZZX-Ai/bilibili-mcp) | 面向中文用户的 Bilibili MCP 服务器，可提取视频元数据、字幕与结构化转录、章节和热门评论，并在无字幕时支持本地 ASR 回退。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, npm: `@xzxzzx/bilibili-mcp`。 |
 | [ElevenLabs (官方)](https://github.com/elevenlabs/elevenlabs-mcp) | ElevenLabs 官方 MCP 服务器，提供文本转语音、语音克隆、音频转录、配音等能力。 | 官方实现 (ElevenLabs) 🎖️, Python 开发 🐍, 云服务 ☁️, 语音合成 TTS。 |
 | [MiniMax (官方)](https://github.com/MiniMax-AI/MiniMax-MCP) | MiniMax 官方 MCP 服务器，调用其文本转语音、图像生成与视频生成 API。 | 官方实现 (MiniMax) 🎖️, Python 开发 🐍, 云服务 ☁️, 语音/图像/视频生成。 |
-| [RunComfy (官方)](https://github.com/runcomfy-com/runcomfy-mcp) | RunComfy 官方远程 MCP 服务器，调用其 Serverless API (ComfyUI)：创建/管理 GPU 部署、提交异步推理、获取图像/视频结果。官网 https://www.runcomfy.com ，远程端点 https://mcp.runcomfy.com/mcp。 | 官方实现 (RunComfy) 🎖️, Python 开发 🐍, 云服务 ☁️, ComfyUI 图像/视频生成。 |
+| [RunComfy (官方)](https://github.com/runcomfy-com/runcomfy-mcp) | RunComfy 官方远程 MCP 服务器，共 31 个工具，覆盖三块能力：ComfyUI Serverless 部署（创建/更新/删除部署、提交异步推理、查询结果、取消请求、实例代理）、托管模型推理（浏览模型与分类、运行模型、查询/取消任务）、LoRA 训练（数据集创建与上传、提交/查询/取消/恢复/编辑训练任务），另可查询账户余额。官网 https://www.runcomfy.com ，远程端点 https://mcp.runcomfy.com/mcp。 | 官方实现 (RunComfy) 🎖️, Python 开发 🐍, 云服务 ☁️, 远程端点 Streamable HTTP + Bearer Token, 31 个工具, MCP Registry: `io.github.runcomfy-com/runcomfy-mcp` v1.1.0, ComfyUI 图像/视频生成与 LoRA 训练。 |
 | [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio) | 通过 MCP 让编码 Agent 按可编辑时间线编排、编辑、生成并自动组装视频。 | 官方实现 🎖️, TypeScript 开发 📇, 本地运行 🏠, MCP 服务器/命令行/技能集。 |
 | [freeaudiototext-mcp](https://github.com/double2dev/freeaudiototext-mcp) | FreeAudioToText 官方出品的音视频转录 MCP 服务器。让 AI 直接读取音视频文件或 YouTube/TikTok 链接，一键生成带有精准“说话人分离”的高质量文字。纯免费、无时间限制。 | 官方实现 🎖️, TypeScript 开发 📇, 本地/边缘混合 🏠☁️, 音视频转录。 |
 


### PR DESCRIPTION
更新已收录条目 **RunComfy (官方)**（README.md 第 898 行），仅改这一行，不涉及其他条目。

原条目写于 v1.0 时期，只描述了 Serverless (ComfyUI) 部署与异步推理，共 10 个工具。服务端已升级到 v1.1.0，工具数量从 10 增加到 31，并新增两块能力：

- **托管模型推理**：浏览模型与分类、运行模型、查询/取消任务
- **LoRA 训练**：数据集创建与上传、提交/查询/取消/恢复/编辑训练任务

备注列同步补充了传输方式（Streamable HTTP + Bearer Token）、工具数量和 MCP Registry 名称 `io.github.runcomfy-com/runcomfy-mcp` v1.1.0。

仓库：https://github.com/runcomfy-com/runcomfy-mcp
官网：https://www.runcomfy.com
远程端点：https://mcp.runcomfy.com/mcp

保持三列表格格式与原位置不变。
