### PR TITLE
更新 RunComfy 条目：10 个工具 → 31 个工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,7 +895,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Bilibili MCP](https://github.com/XZXZZX-Ai/bilibili-mcp) | 面向中文用户的 Bilibili MCP 服务器，可提取视频元数据、字幕与结构化转录、章节和热门评论，并在无字幕时支持本地 ASR 回退。 | 社区实现, TypeScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, npm: `@xzxzzx/bilibili-mcp`。 |
 | [ElevenLabs (官方)](https://github.com/elevenlabs/elevenlabs-mcp) | ElevenLabs 官方 MCP 服务器，提供文本转语音、语音克隆、音频转录、配音等能力。 | 官方实现 (ElevenLabs) 🎖️, Python 开发 🐍, 云服务 ☁️, 语音合成 TTS。 |
 | [MiniMax (官方)](https://github.com/MiniMax-AI/MiniMax-MCP) | MiniMax 官方 MCP 服务器，调用其文本转语音、图像生成与视频生成 API。 | 官方实现 (MiniMax) 🎖️, Python 开发 🐍, 云服务 ☁️, 语音/图像/视频生成。 |
-| [RunComfy (官方)](https://github.com/runcomfy-com/runcomfy-mcp) | RunComfy 官方远程 MCP 服务器，调用其 Serverless API (ComfyUI)：创建/管理 GPU 部署、提交异步推理、获取图像/视频结果。官网 https://www.runcomfy.com ，远程端点 https://mcp.runcomfy.com/mcp。 | 官方实现 (RunComfy) 🎖️, Python 开发 🐍, 云服务 ☁️, ComfyUI 图像/视频生成。 |
+| [RunComfy (官方)](https://github.com/runcomfy-com/runcomfy-mcp) | RunComfy 官方远程 MCP 服务器，共 31 个工具，覆盖三类能力：ComfyUI Serverless 部署管理与异步推理、托管模型直接调用、LoRA 训练（数据集上传、提交/查询/续跑/编辑训练任务）。官网 https://www.runcomfy.com ，远程端点 https://mcp.runcomfy.com/mcp。 | 官方实现 (RunComfy) 🎖️, Python 开发 🐍, 云服务 ☁️, ComfyUI 图像/视频生成 + LoRA 训练。 |
 | [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio) | 通过 MCP 让编码 Agent 按可编辑时间线编排、编辑、生成并自动组装视频。 | 官方实现 🎖️, TypeScript 开发 📇, 本地运行 🏠, MCP 服务器/命令行/技能集。 |
 | [freeaudiototext-mcp](https://github.com/double2dev/freeaudiototext-mcp) | FreeAudioToText 官方出品的音视频转录 MCP 服务器。让 AI 直接读取音视频文件或 YouTube/TikTok 链接，一键生成带有精准“说话人分离”的高质量文字。纯免费、无时间限制。 | 官方实现 🎖️, TypeScript 开发 📇, 本地/边缘混合 🏠☁️, 音视频转录。 |
 


### PR DESCRIPTION
RunComfy 官方 MCP 服务器已从 10 个工具扩展到 31 个，新增了托管模型调用和 LoRA 训练两类能力。原条目（README.md 第 898 行，PR #391 合并）只描述了 Serverless 部署和异步推理，已过期。

本 PR 只改这一行，格式和列数与相邻条目保持一致。

- 仓库：https://github.com/runcomfy-com/runcomfy-mcp
- 远程端点：https://mcp.runcomfy.com/mcp
- 官方 Registry：io.github.runcomfy-com/runcomfy-mcp v1.1.0