### PR TITLE
新增 ZeroSMTP 到 💬 通讯与协作

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Nylas CLI](https://github.com/nylas/cli) | 邮件、日历和联系人 MCP 服务器。一次身份验证即可覆盖 Gmail、Outlook、Exchange、Yahoo、iCloud 和 IMAP 共六大邮件服务商的 16 个工具。`nylas mcp install` 一键安装。 | 官方实现 (Nylas) 🎖️, Go 开发 🏎️, 云服务 ☁️, 跨平台 🍎🪟🐧, 邮件/日历/联系人统一接入。文档：https://cli.nylas.com |
 | [TwitterAPI.io MCP Server](https://github.com/kaitoInfra/twitterapi-io-mcp-server) | 对接 twitterapi.io（Twitter/X 数据 API）的官方 MCP 服务器。12 个只读工具：推文搜索（支持完整搜索操作符）、用户档案、关注者、对话线程、趋势话题、互动指标。npm `@twitterapi_io/mcp-server`。 | 官方实现 🎖️, TypeScript 开发 📇, 云服务 ☁️, X/Twitter 数据 API 集成。 |
 | [Manto（馒头新闻）](https://github.com/tans/manto) | 面向 AI Agent 的公共消息网络：Agent 可创建身份、发布时效消息、搜索其他 Agent 发布的内容。搜索与公开账户查询无需鉴权，发布与推广使用 Bearer API Key。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, MIT, Streamable HTTP `https://manto.xin/mcp`, MCP Registry: `io.github.tans/manto`。 |
+| [ZeroSMTP](https://github.com/msgwing/ZeroSMTP/tree/main/packages/zerosmtp-mcp) | 面向 Microsoft 365 在 2026 年 12 月停用 SMTP AUTH 基本身份验证的诊断服务器：解释 SMTP 报错字符串、按厂商查询打印机/扫描仪是否已有 OAuth 固件（依据厂商公开声明并附链接）、返回免费中继的连接参数（每次都会一并给出两项限制：每天 200 封，发件地址为随机生成的 @msgwing.com 而非自有域名），以及从本机发起真实的 TCP+TLS 握手来测试 587 端口是否可达。 | 官方实现 (MsgWing) 🎖️, JavaScript 开发 📇, 本地运行 🏠, 跨平台 🍎🪟🐧, 零依赖、无遥测, `npx -y zerosmtp-mcp`。 |
 
 ---
 


### PR DESCRIPTION
新增一个 MCP Server 条目到 `💬 通讯与协作`。

**利益关系声明：我是 ZeroSMTP 的维护者，这是自荐条目。**

- 仓库：https://github.com/msgwing/ZeroSMTP/tree/main/packages/zerosmtp-mcp
- npm：`zerosmtp-mcp`（已发布，MIT，零依赖，Node ≥ 18，stdio 传输）
- 已收录于官方 MCP Registry：`io.github.msgwing/zerosmtp`

它解决的问题：微软将在 2026 年 12 月对现有 Microsoft 365 租户默认关闭 SMTP AUTH 的基本身份验证。打印机、扫描仪、NAS 以及无法使用 OAuth 的旧应用会因此停止发信，而错误信息通常只是一串数字代码。

四个工具：

- `lookup_smtp_error` — 解释 `535 5.7.139` 这类报错到底是什么意思，以及管理员现在是否还能撤销其成因
- `check_device_oauth` — 按厂商查询某台打印机/扫描仪是否已有支持 OAuth 的固件，依据厂商自己的公开声明并附上链接
- `relay_settings` — 返回连接参数，并且**每次都会一并给出两项限制**：每天 200 封，发件地址是随机生成的 `@msgwing.com` 而非用户自有域名。如果对方必须用自己的域名发信，ZeroSMTP 就不是正确答案，README 里也是这么写的
- `check_relay_reachable` — 从**提问者所在的这台机器**发起真实的 TCP 连接与 TLS 握手，报告往返时间、协商出的 TLS 版本、加密套件与证书。助手可以读文档，但打不开一个 socket；而「这里 587 端口通不通」往往才是决定打印机能否发信的那个问题。它不发送任何凭据，也不发送任何邮件

无遥测：除了你明确要求测试的那台主机之外，没有任何出站连接。

按贡献指南自查：真实且可验证的 MCP Server（有公开仓库与服务端源码）、可通过 npm 安装并以一条命令调用、README 说明了工具与接入方式、非付费墙套壳、非聚合目录、条目此前未收录（已在 README 中检索 `zerosmtp` 与 `msgwing`，均无结果）。

条目按当前实践追加在该分类末尾（最近数个合并的条目均为追加）。如需改为严格拼音位置，请告知，我会调整。
