### PR TITLE
新增 You.com 官方远程 MCP 服务器到 搜索

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,7 @@ MCP 客户端是 AI 的“操作台”，以下是几个热门选择：
 | [Episkey-G/GrokSearch-rs](https://github.com/Episkey-G/GrokSearch-rs) | Rust 编写的 MCP 服务器，提供 Grok 联网搜索与 Tavily 支持的来源检索，为 AI 代理补充实时网络信息。 | 社区实现, Rust 开发 🦀, 云服务 ☁️, Grok 联网搜索 + Tavily 检索。 |
 | [NovadaLabs/Novada-mcp](https://github.com/NovadaLabs/Novada-mcp) | 托管 Streamable-HTTP MCP 服务器，提供 25+ 网页数据工具：搜索、SERP、抓取、提取、地图、爬取、深度研究及 6 种代理类型，覆盖 195 个国家。免安装，每月 1000 次免费调用。`npx novada-mcp` | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 全面网页数据采集平台, MIT。 |
 | [Brave Search (官方)](https://github.com/brave/brave-search-mcp-server) | Brave 官方出品的搜索 MCP 服务器，支持网页、本地、图片、新闻、视频搜索。 | 官方实现 (Brave) 🎖️, TypeScript 开发 📇, 云服务 ☁️, Brave 搜索引擎。 |
+| [You.com](https://github.com/youdotcom-oss/agent-skills) | You.com 官方远程 MCP 服务器，提供实时网页搜索、URL 内容提取与带引用的深度研究（工具 `you-search` / `you-contents` / `you-research`），并附赠多平台 Agent 技能包（Claude Code、Codex、Cursor、Copilot CLI 等）。 | 官方实现 (You.com) 🎖️, 云服务 ☁️, 远程端点 `https://api.you.com/mcp`，支持 `YDC_API_KEY` Bearer 认证或免密 `?profile=free` 基础搜索，MIT。 |
 | [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) | 跨境电商商品目录 MCP：跨 SG/MY/VN/TH/PH/US/JP 七个国家 3.7 亿+ 商品实时搜索与比价（`deliver_to` 配送信号），覆盖 13 个工具（search_products / find_best_price / get_deals 等）。OAuth 2.1 Bearer 鉴权，免邮箱注册。已上架官方 MCP Registry（`io.github.BuyWhere/buywhere-mcp@1.1.0`）。 | 社区实现, TypeScript 开发 📇, 云服务 ☁️, 远程端点 `https://mcp.buywhere.ai/mcp`, MIT。 |
 
 ---


### PR DESCRIPTION
在「搜索」分类新增 You.com 官方远程 MCP 服务器条目，与现有的 Exa、Tavily、Kagi、Perplexity、Brave 官方搜索条目并列。

## 项目介绍

[You.com](https://github.com/youdotcom-oss/agent-skills) 是 You.com 官方维护的 Agent 技能与 MCP 打包仓库（MIT）。远程 MCP 服务器位于 `https://api.you.com/mcp`，提供：

- `you-search` - 实时网页搜索
- `you-contents` - URL 内容提取与清洗
- `you-research` - 带引用来源的深度研究

认证方式两种：`YDC_API_KEY` Bearer 认证，或免密 `https://api.you.com/mcp?profile=free`（基础搜索，无需 API Key）。仓库同时附带多平台技能包（Claude Code、Codex、Cursor、Copilot CLI、OpenCode 等，`npx skills add youdotcom-oss/agent-skills`）。

## 收录自查（对照贡献指南）

- **真实可验证**：远程端点为稳定的 HTTPS Streamable HTTP 服务（提交前已用 MCP `initialize` 请求实测返回 200 / `text/event-stream`）；仓库开源、有文档、有维护（最近一次推送 2026-08-31）。
- **可安装 / 可调用**：远程端点直接接入，无需本地安装；客户端配置示例见仓库 README。
- **文档清晰**：README 说明了工具清单、认证方式与各平台安装命令。
- **非重复条目**：检索全篇 README，目前无 You.com 相关条目。

## 修改范围

仅一行：`README.md` 搜索分类表格新增一条，遵循 CONTRIBUTING.md 的三列格式（名称 / 中文介绍 / 备注），未改动其他任何内容。

如有格式或措辞需要调整的地方，欢迎指出，我可以直接修改。
